### PR TITLE
Changed file format to Xojo 2014r3.2

### DIFF
--- a/Views/BlockanimationView.xojo_code
+++ b/Views/BlockanimationView.xojo_code
@@ -10,9 +10,9 @@ Begin iosView BlockanimationView
    Begin iOSButton AFrameButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AFrameButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AFrameButton, 7, , 0, False, +1.00, 1, 1, 100, 
       AutoLayout      =   AFrameButton, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   AFrameButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AFrameButton, 4, ARotationButton, 3, False, +1.00, 1, 1, -*kStdControlGapV, 
       Caption         =   "Animate Frame"
       Enabled         =   True
@@ -43,9 +43,9 @@ Begin iosView BlockanimationView
    Begin iostextfield DurationField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DurationField, 7, , 0, False, +1.00, 2, 1, 43, 
       AutoLayout      =   DurationField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   DurationField, 4, Label4, 4, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   DurationField, 7, , 0, False, +1.00, 2, 1, 43, 
       AutoLayout      =   DurationField, 2, Label3, 2, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
@@ -67,9 +67,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label1, 3, TopLayoutGuide, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label1, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   Label1, 7, , 0, False, +1.00, 1, 1, 64, 
-      AutoLayout      =   Label1, 3, TopLayoutGuide, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label1, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -88,9 +88,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label2
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label2, 7, , 0, False, +1.00, 1, 1, 46, 
       AutoLayout      =   Label2, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label2, 3, Label1, 4, False, +1.00, 2, 1, *kStdControlGapV, 
-      AutoLayout      =   Label2, 7, , 0, False, +1.00, 1, 1, 46, 
       AutoLayout      =   Label2, 1, Label1, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   21.0
@@ -109,9 +109,9 @@ Begin iosView BlockanimationView
    Begin iostextfield FXField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FXField, 3, Label2, 4, False, +1.00, 2, 1, 5, 
       AutoLayout      =   FXField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   FXField, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
-      AutoLayout      =   FXField, 3, Label2, 4, False, +1.00, 2, 1, 5, 
       AutoLayout      =   FXField, 7, , 0, False, +1.00, 2, 1, 45, 
       Enabled         =   True
       Height          =   31.0
@@ -133,9 +133,9 @@ Begin iosView BlockanimationView
    Begin iostextfield FYField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FYField, 2, FXField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FYField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   FYField, 1, FXField, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   FYField, 2, FXField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FYField, 3, FXField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   31.0
@@ -157,9 +157,9 @@ Begin iosView BlockanimationView
    Begin iostextfield FWField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FWField, 2, FYField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FWField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   FWField, 1, FYField, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   FWField, 2, FYField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FWField, 3, FYField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   31.0
@@ -181,9 +181,9 @@ Begin iosView BlockanimationView
    Begin iostextfield FHField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FHField, 3, FWField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   FHField, 1, FWField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FHField, 2, FWField, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   FHField, 3, FWField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   FHField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -205,9 +205,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label3, 1, Label2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label3, 7, , 0, False, +1.00, 1, 1, 58, 
       AutoLayout      =   Label3, 3, Label2, 3, False, +1.00, 2, 1, 0, 
-      AutoLayout      =   Label3, 1, Label2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label3, 8, , 0, False, +1.00, 1, 1, 21, 
       Enabled         =   True
       Height          =   21.0
@@ -226,9 +226,9 @@ Begin iosView BlockanimationView
    Begin iostextfield BHField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BHField, 3, FHField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BHField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   BHField, 2, BWField, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BHField, 3, FHField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BHField, 7, , 0, False, +1.00, 1, 1, 45, 
       Enabled         =   True
       Height          =   31.0
@@ -250,9 +250,9 @@ Begin iosView BlockanimationView
    Begin iostextfield BWField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BWField, 3, FWField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BWField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   BWField, 2, BYField, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BWField, 3, FWField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BWField, 7, , 0, False, +1.00, 1, 1, 45, 
       Enabled         =   True
       Height          =   31.0
@@ -274,9 +274,9 @@ Begin iosView BlockanimationView
    Begin iostextfield BXField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BXField, 3, FXField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BXField, 1, Label3, 1, False, +1.00, 2, 1, 0, 
       AutoLayout      =   BXField, 7, , 0, False, +1.00, 1, 1, 45, 
-      AutoLayout      =   BXField, 3, FXField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BXField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -298,9 +298,9 @@ Begin iosView BlockanimationView
    Begin iostextfield BYField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BYField, 3, FYField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BYField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   BYField, 2, BXField, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BYField, 3, FYField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BYField, 7, , 0, False, +1.00, 1, 1, 45, 
       Enabled         =   True
       Height          =   31.0
@@ -322,9 +322,9 @@ Begin iosView BlockanimationView
    Begin iOSButton ABoundsButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ABoundsButton, 3, AFrameButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ABoundsButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   ABoundsButton, 1, AFrameButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ABoundsButton, 3, AFrameButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ABoundsButton, 7, , 0, False, +1.00, 1, 1, 114, 
       Caption         =   "Animate Bounds"
       Enabled         =   True
@@ -342,13 +342,13 @@ Begin iosView BlockanimationView
    Begin iOSSwitch Begincurrent
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Begincurrent, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   Begincurrent, 3, Label1, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Begincurrent, 7, , 0, True, +1.00, 1, 1, 51, 
       AutoLayout      =   Begincurrent, 2, <Parent>, 2, False, +1.00, 1, 1, -*kStdGapCtlToViewH, 
+      AutoLayout      =   Begincurrent, 3, Label1, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Begincurrent, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Begincurrent, 7, , 0, True, +1.00, 1, 1, 51, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   953
+      Left            =   249
       LockedInPosition=   False
       Scope           =   0
       Top             =   73
@@ -359,13 +359,13 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label4
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label4, 3, Begincurrent, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label4, 2, Begincurrent, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   Label4, 7, , 0, False, +1.00, 1, 1, 127, 
-      AutoLayout      =   Label4, 3, Begincurrent, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label4, 4, Label3, 3, False, +1.00, 1, 1, -*kStdControlGapV, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   818
+      Left            =   114
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Begin from current"
@@ -380,13 +380,13 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label5
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label5, 2, Repeat, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   Label5, 7, , 0, False, +1.00, 1, 1, 163, 
       AutoLayout      =   Label5, 3, Repeat, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label5, 2, Repeat, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   Label5, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   782
+      Left            =   78
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Repeat"
@@ -401,13 +401,13 @@ Begin iosView BlockanimationView
    Begin iOSSwitch Repeat
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Repeat, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Repeat, 3, Begincurrent, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Repeat, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   Repeat, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Repeat, 3, Begincurrent, 4, False, +1.00, 1, 1, *kStdControlGapV, 
+      AutoLayout      =   Repeat, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Repeat, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   953
+      Left            =   249
       LockedInPosition=   False
       Scope           =   0
       Top             =   112
@@ -418,13 +418,13 @@ Begin iosView BlockanimationView
    Begin iOSSwitch AutoReverse
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   AutoReverse, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   AutoReverse, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
-      AutoLayout      =   AutoReverse, 3, Repeat, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   AutoReverse, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   AutoReverse, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
+      AutoLayout      =   AutoReverse, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   AutoReverse, 3, Repeat, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   953
+      Left            =   249
       LockedInPosition=   False
       Scope           =   0
       Top             =   151
@@ -435,13 +435,13 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label6
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label6, 2, AutoReverse, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   Label6, 7, , 0, False, +1.00, 1, 1, 163, 
       AutoLayout      =   Label6, 3, AutoReverse, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label6, 2, AutoReverse, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   Label6, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   782
+      Left            =   78
       LockedInPosition=   False
       Scope           =   0
       Text            =   "AutoReverse"
@@ -456,14 +456,14 @@ Begin iosView BlockanimationView
    Begin iOSButton SBoundsButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SBoundsButton, 3, ABoundsButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SBoundsButton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   SBoundsButton, 7, , 0, False, +1.00, 1, 1, 86, 
-      AutoLayout      =   SBoundsButton, 3, ABoundsButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SBoundsButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set Bounds"
       Enabled         =   True
       Height          =   30.0
-      Left            =   918
+      Left            =   214
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -476,14 +476,14 @@ Begin iosView BlockanimationView
    Begin iOSButton SFrameButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SFrameButton, 3, SBoundsButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SFrameButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SFrameButton, 2, SBoundsButton, 1, False, +1.00, 4, 1, -16, 
-      AutoLayout      =   SFrameButton, 3, SBoundsButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SFrameButton, 7, , 0, False, +1.00, 1, 1, 73, 
       Caption         =   "Set Frame"
       Enabled         =   True
       Height          =   30.0
-      Left            =   829
+      Left            =   125
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -496,9 +496,9 @@ Begin iosView BlockanimationView
    Begin iOSSegmentedControl AnimationOptControl
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AnimationOptControl, 8, , 0, True, +1.00, 1, 1, 29, 
       AutoLayout      =   AnimationOptControl, 7, , 0, False, +1.00, 1, 1, 215, 
       AutoLayout      =   AnimationOptControl, 1, <Parent>, 1, False, +1.00, 2, 1, *kStdGapCtlToViewH, 
-      AutoLayout      =   AnimationOptControl, 8, , 0, True, +1.00, 1, 1, 29, 
       AutoLayout      =   AnimationOptControl, 4, SFrameButton, 3, False, +1.00, 1, 1, -*kStdControlGapV, 
       Caption         =   ""
       Enabled         =   True
@@ -515,9 +515,9 @@ Begin iosView BlockanimationView
    Begin ioslabel TextArea1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TextArea1, 4, AnimationOptControl, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       AutoLayout      =   TextArea1, 1, AnimationOptControl, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TextArea1, 2, SBoundsButton, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   TextArea1, 4, AnimationOptControl, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       AutoLayout      =   TextArea1, 8, , 0, False, +1.00, 2, 1, 97, 
       Enabled         =   False
       Height          =   97.0
@@ -531,18 +531,18 @@ Begin iosView BlockanimationView
       TextSize        =   0
       Top             =   262
       Visible         =   True
-      Width           =   984.0
+      Width           =   280.0
       Begin iostextfield TrF0
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   TrF0, 3, VelocityField, 4, False, +1.00, 1, 1, 28, 
          AutoLayout      =   TrF0, 8, , 0, False, +1.00, 1, 1, 31, 
          AutoLayout      =   TrF0, 2, VelocityField, 2, False, +1.00, 2, 1, 0, 
-         AutoLayout      =   TrF0, 3, VelocityField, 4, False, +1.00, 1, 1, 28, 
          AutoLayout      =   TrF0, 7, , 0, False, +1.00, 1, 1, 45, 
          Enabled         =   False
          Height          =   31.0
          KeyboardType    =   "2"
-         Left            =   959
+         Left            =   255
          LockedInPosition=   False
          PanelIndex      =   0
          Parent          =   "TextArea1"
@@ -561,14 +561,14 @@ Begin iosView BlockanimationView
       Begin iostextfield TRFB
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   TRFB, 3, TrF0, 3, False, +1.00, 1, 1, 0, 
          AutoLayout      =   TRFB, 8, , 0, False, +1.00, 2, 1, 31, 
          AutoLayout      =   TRFB, 2, TrF0, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-         AutoLayout      =   TRFB, 3, TrF0, 3, False, +1.00, 1, 1, 0, 
          AutoLayout      =   TRFB, 7, , 0, False, +1.00, 1, 1, 79, 
          Enabled         =   False
          Height          =   31.0
          KeyboardType    =   "2"
-         Left            =   872
+         Left            =   168
          LockedInPosition=   False
          PanelIndex      =   0
          Parent          =   "TextArea1"
@@ -587,14 +587,14 @@ Begin iosView BlockanimationView
       Begin iostextfield TRFA
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   TRFA, 3, TRFB, 3, False, +1.00, 1, 1, 0, 
          AutoLayout      =   TRFA, 2, TRFB, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
          AutoLayout      =   TRFA, 7, , 0, False, +1.00, 1, 1, 79, 
-         AutoLayout      =   TRFA, 3, TRFB, 3, False, +1.00, 1, 1, 0, 
          AutoLayout      =   TRFA, 8, , 0, False, +1.00, 1, 1, 31, 
          Enabled         =   False
          Height          =   31.0
          KeyboardType    =   "2"
-         Left            =   785
+         Left            =   81
          LockedInPosition=   False
          PanelIndex      =   0
          Parent          =   "TextArea1"
@@ -614,13 +614,13 @@ Begin iosView BlockanimationView
    Begin iOSLabel AnimationEndedLabel
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AnimationEndedLabel, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AnimationEndedLabel, 4, TextArea1, 4, False, +1.00, 2, 1, -*kStdControlGapV, 
       AutoLayout      =   AnimationEndedLabel, 9, <Parent>, 9, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   AnimationEndedLabel, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AnimationEndedLabel, 7, , 0, False, +1.00, 2, 1, 250, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   387
+      Left            =   35
       LockedInPosition=   False
       Scope           =   0
       Text            =   ""
@@ -635,9 +635,9 @@ Begin iosView BlockanimationView
    Begin iostextfield BGColorField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BGColorField, 2, BHField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BGColorField, 8, , 0, False, +1.00, 1, 1, 36, 
       AutoLayout      =   BGColorField, 1, TextArea1, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BGColorField, 2, BHField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BGColorField, 3, Label7, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   36.0
@@ -659,9 +659,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label7
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label7, 3, BHField, 4, False, +1.00, 2, 1, *kStdControlGapV, 
       AutoLayout      =   Label7, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label7, 1, BGColorField, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label7, 3, BHField, 4, False, +1.00, 2, 1, *kStdControlGapV, 
       AutoLayout      =   Label7, 7, , 0, False, +1.00, 1, 1, 137, 
       Enabled         =   True
       Height          =   21.0
@@ -680,14 +680,14 @@ Begin iosView BlockanimationView
    Begin iOSButton SFrameButton1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SFrameButton1, 3, SFrameButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SFrameButton1, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SFrameButton1, 2, SFrameButton, 1, False, +1.00, 4, 1, -*kStdControlGapH, 
-      AutoLayout      =   SFrameButton1, 3, SFrameButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SFrameButton1, 7, , 0, False, +1.00, 1, 1, 92, 
       Caption         =   "Set BGColor"
       Enabled         =   True
       Height          =   30.0
-      Left            =   729
+      Left            =   25
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -700,9 +700,9 @@ Begin iosView BlockanimationView
    Begin iOSButton AColorButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AColorButton, 3, ABoundsButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AColorButton, 1, ABoundsButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   AColorButton, 7, , 0, False, +1.00, 1, 1, 119, 
-      AutoLayout      =   AColorButton, 3, ABoundsButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AColorButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Animate BGColor"
       Enabled         =   True
@@ -720,13 +720,13 @@ Begin iosView BlockanimationView
    Begin iOSSwitch Spring
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Spring, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Spring, 3, AutoReverse, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Spring, 2, AutoReverse, 2, False, +1.00, 2, 1, 0, 
       AutoLayout      =   Spring, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Spring, 3, AutoReverse, 4, False, +1.00, 1, 1, *kStdControlGapV, 
+      AutoLayout      =   Spring, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Spring, 2, AutoReverse, 2, False, +1.00, 2, 1, 0, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   953
+      Left            =   249
       LockedInPosition=   False
       Scope           =   0
       Top             =   190
@@ -737,13 +737,13 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label8
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label8, 3, Spring, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label8, 8, , 0, False, +1.00, 2, 1, 30, 
       AutoLayout      =   Label8, 2, Spring, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label8, 3, Spring, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label8, 7, , 0, False, +1.00, 1, 1, 135, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   810
+      Left            =   106
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Spring Animation"
@@ -758,9 +758,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label9
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label9, 1, DurationField, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label9, 7, , 0, False, +1.00, 1, 1, 41, 
       AutoLayout      =   Label9, 3, Label4, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label9, 1, DurationField, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label9, 4, Label4, 4, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   30.0
@@ -779,9 +779,9 @@ Begin iosView BlockanimationView
    Begin iostextfield DelayField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DelayField, 3, Label9, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DelayField, 1, Label9, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   DelayField, 7, , 0, False, +1.00, 1, 1, 43, 
-      AutoLayout      =   DelayField, 3, Label9, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DelayField, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -803,14 +803,14 @@ Begin iosView BlockanimationView
    Begin iostextfield DampingField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DampingField, 3, Spring, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   DampingField, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   DampingField, 1, Spring, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   DampingField, 3, Spring, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   DampingField, 7, , 0, False, +1.00, 1, 1, 51, 
       Enabled         =   True
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   953
+      Left            =   249
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   ""
@@ -827,8 +827,8 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label10
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Label10, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label10, 2, DampingField, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
+      AutoLayout      =   Label10, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label10, 3, Spring, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   30.0
@@ -842,18 +842,18 @@ Begin iosView BlockanimationView
       TextSize        =   0
       Top             =   229
       Visible         =   True
-      Width           =   108.0
+      Width           =   -596.0
    End
    Begin iOSLabel Label11
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label11, 3, DampingField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label11, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label11, 2, VelocityField, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label11, 3, DampingField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label11, 7, , 0, False, +1.00, 1, 1, 108, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   837
+      Left            =   133
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Velocity"
@@ -868,14 +868,14 @@ Begin iosView BlockanimationView
    Begin iostextfield VelocityField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   VelocityField, 2, DampingField, 2, False, +1.00, 2, 1, 0, 
       AutoLayout      =   VelocityField, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   VelocityField, 1, DampingField, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   VelocityField, 2, DampingField, 2, False, +1.00, 2, 1, 0, 
       AutoLayout      =   VelocityField, 3, DampingField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   953
+      Left            =   249
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   ""
@@ -892,14 +892,14 @@ Begin iosView BlockanimationView
    Begin iOSButton ResetButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ResetButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   ResetButton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   ResetButton, 7, , 0, False, +1.00, 1, 1, 67, 
-      AutoLayout      =   ResetButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   ResetButton, 4, SBoundsButton, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       Caption         =   "Reset"
       Enabled         =   True
       Height          =   30.0
-      Left            =   937
+      Left            =   233
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -912,9 +912,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label12
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label12, 3, BGColorField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label12, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label12, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   Label12, 3, BGColorField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label12, 7, , 0, False, +1.00, 1, 1, 137, 
       Enabled         =   True
       Height          =   21.0
@@ -933,9 +933,9 @@ Begin iosView BlockanimationView
    Begin iostextfield RotationField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   RotationField, 3, Label12, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   RotationField, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   RotationField, 7, , 0, False, +1.00, 1, 1, 99, 
-      AutoLayout      =   RotationField, 3, Label12, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   RotationField, 8, , 0, False, +1.00, 1, 1, 36, 
       Enabled         =   True
       Height          =   36.0
@@ -957,13 +957,13 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label13
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label13, 1, TRFA, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label13, 4, TRFA, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       AutoLayout      =   Label13, 8, , 0, False, +1.00, 1, 1, 21, 
-      AutoLayout      =   Label13, 1, TRFA, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label13, 7, , 0, False, +1.00, 1, 1, 137, 
       Enabled         =   True
       Height          =   21.0
-      Left            =   785
+      Left            =   81
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Transformation"
@@ -978,8 +978,8 @@ Begin iosView BlockanimationView
    Begin iOSButton ARotationButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   ARotationButton, 4, BottomLayoutGuide, 3, False, +1.00, 4, 1, -*kStdControlGapV, 
       AutoLayout      =   ARotationButton, 8, , 0, False, +1.00, 1, 1, 30, 
+      AutoLayout      =   ARotationButton, 4, BottomLayoutGuide, 3, False, +1.00, 4, 1, -*kStdControlGapV, 
       AutoLayout      =   ARotationButton, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       Caption         =   "Animate Rotation"
       Enabled         =   True
@@ -992,19 +992,19 @@ Begin iosView BlockanimationView
       TextSize        =   0
       Top             =   442
       Visible         =   True
-      Width           =   -248.0
+      Width           =   -148.0
    End
    Begin iostextfield TrF01
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrF01, 3, TrF0, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrF01, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   TrF01, 1, TrF0, 1, False, +1.00, 2, 1, 0, 
-      AutoLayout      =   TrF01, 3, TrF0, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrF01, 7, , 0, False, +1.00, 1, 1, 45, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   959
+      Left            =   255
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "0"
@@ -1021,14 +1021,14 @@ Begin iosView BlockanimationView
    Begin iostextfield TrF1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrF1, 3, TrF01, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrF1, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   TrF1, 1, TrFTY, 2, False, +1.00, 2, 1, *kStdControlGapH, 
-      AutoLayout      =   TrF1, 3, TrF01, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrF1, 7, , 0, False, +1.00, 1, 1, 45, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   959
+      Left            =   255
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "1"
@@ -1045,14 +1045,14 @@ Begin iosView BlockanimationView
    Begin iostextfield TrFTY
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFTY, 3, TrF1, 3, False, +1.00, 1, 1, 1, 
       AutoLayout      =   TrFTY, 1, TrFD, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TrFTY, 7, , 0, False, +1.00, 1, 1, 79, 
-      AutoLayout      =   TrFTY, 3, TrF1, 3, False, +1.00, 1, 1, 1, 
       AutoLayout      =   TrFTY, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   872
+      Left            =   168
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "1"
@@ -1069,14 +1069,14 @@ Begin iosView BlockanimationView
    Begin iostextfield TrFD
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFD, 3, TrF01, 3, False, +1.00, 1, 1, 1, 
       AutoLayout      =   TrFD, 2, TrF01, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   TrFD, 7, , 0, False, +1.00, 1, 1, 79, 
-      AutoLayout      =   TrFD, 3, TrF01, 3, False, +1.00, 1, 1, 1, 
       AutoLayout      =   TrFD, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   872
+      Left            =   168
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "0"
@@ -1093,14 +1093,14 @@ Begin iosView BlockanimationView
    Begin iostextfield TrFC
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFC, 3, TRFA, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrFC, 2, TRFA, 2, False, +1.00, 2, 1, 0, 
       AutoLayout      =   TrFC, 7, , 0, False, +1.00, 1, 1, 79, 
-      AutoLayout      =   TrFC, 3, TRFA, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrFC, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   785
+      Left            =   81
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "0"
@@ -1117,14 +1117,14 @@ Begin iosView BlockanimationView
    Begin iostextfield TrFTX
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFTX, 3, TrFC, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrFTX, 1, TrFC, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TrFTX, 7, , 0, False, +1.00, 1, 1, 79, 
-      AutoLayout      =   TrFTX, 3, TrFC, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   TrFTX, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   785
+      Left            =   81
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "1"
@@ -1141,14 +1141,14 @@ Begin iosView BlockanimationView
    Begin iOSButton Setrotationbutton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Setrotationbutton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   Setrotationbutton, 7, , 0, False, +1.00, 2, 1, 100, 
       AutoLayout      =   Setrotationbutton, 3, ARotationButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Setrotationbutton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   Setrotationbutton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set Rotation"
       Enabled         =   True
       Height          =   30.0
-      Left            =   904
+      Left            =   200
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1161,9 +1161,9 @@ Begin iosView BlockanimationView
    Begin iostextfield CXField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   CXField, 3, BXField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CXField, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   CXField, 1, BXField, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   CXField, 3, BXField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CXField, 7, , 0, False, +1.00, 1, 1, 45, 
       Enabled         =   True
       Height          =   31.0
@@ -1185,9 +1185,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel CenterLabel
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   CenterLabel, 3, Label3, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   CenterLabel, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   CenterLabel, 1, CXField, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   CenterLabel, 3, Label3, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   CenterLabel, 7, , 0, False, +1.00, 1, 1, 58, 
       Enabled         =   True
       Height          =   21.0
@@ -1206,9 +1206,9 @@ Begin iosView BlockanimationView
    Begin iostextfield CYField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   CYField, 3, BYField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CYField, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   CYField, 1, CXField, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   CYField, 3, BYField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CYField, 7, , 0, False, +1.00, 1, 1, 45, 
       Enabled         =   True
       Height          =   31.0
@@ -1230,14 +1230,14 @@ Begin iosView BlockanimationView
    Begin iOSButton SetCenterbutton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SetCenterbutton, 3, Setrotationbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetCenterbutton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SetCenterbutton, 2, Setrotationbutton, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-      AutoLayout      =   SetCenterbutton, 3, Setrotationbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetCenterbutton, 7, , 0, False, +1.00, 1, 1, 86, 
       Caption         =   "Set Center"
       Enabled         =   True
       Height          =   30.0
-      Left            =   810
+      Left            =   106
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1250,14 +1250,14 @@ Begin iosView BlockanimationView
    Begin iOSButton ACenterButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ACenterButton, 1, ARotationButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ACenterButton, 7, , 0, False, +1.00, 1, 1, 112, 
       AutoLayout      =   ACenterButton, 3, ARotationButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ACenterButton, 1, ARotationButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ACenterButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Animate Center"
       Enabled         =   True
       Height          =   30.0
-      Left            =   -220
+      Left            =   -120
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1270,9 +1270,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label14
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label14, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Label14, 7, , 0, False, +1.00, 1, 1, 137, 
       AutoLayout      =   Label14, 3, RotationField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Label14, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Label14, 8, , 0, False, +1.00, 1, 1, 21, 
       Enabled         =   True
       Height          =   21.0
@@ -1290,9 +1290,9 @@ Begin iosView BlockanimationView
       Begin iOSLabel Label17
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   Label17, 7, , 0, False, +1.00, 1, 1, 137, 
          AutoLayout      =   Label17, 3, Label14, 3, False, +1.00, 1, 1, 0, 
          AutoLayout      =   Label17, 1, Label14, 1, False, +1.00, 1, 1, 0, 
-         AutoLayout      =   Label17, 7, , 0, False, +1.00, 1, 1, 137, 
          AutoLayout      =   Label17, 8, , 0, False, +1.00, 1, 1, 21, 
          Enabled         =   True
          Height          =   21.0
@@ -1314,9 +1314,9 @@ Begin iosView BlockanimationView
    Begin iostextfield Alphafield
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Alphafield, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Alphafield, 7, , 0, False, +1.00, 1, 1, 99, 
       AutoLayout      =   Alphafield, 3, Label14, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Alphafield, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Alphafield, 8, , 0, False, +1.00, 1, 1, 36, 
       Enabled         =   True
       Height          =   36.0
@@ -1338,14 +1338,14 @@ Begin iosView BlockanimationView
    Begin iOSButton AAlphaButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AAlphaButton, 3, ACenterButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AAlphaButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AAlphaButton, 1, ACenterButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   AAlphaButton, 3, ACenterButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AAlphaButton, 7, , 0, False, +1.00, 1, 1, 112, 
       Caption         =   "Animate Alpha"
       Enabled         =   True
       Height          =   30.0
-      Left            =   -100
+      Left            =   0
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1358,14 +1358,14 @@ Begin iosView BlockanimationView
    Begin iOSButton SetAlphaButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SetAlphaButton, 3, SetCenterbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetAlphaButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SetAlphaButton, 2, SetCenterbutton, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-      AutoLayout      =   SetAlphaButton, 3, SetCenterbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetAlphaButton, 7, , 0, False, +1.00, 1, 1, 86, 
       Caption         =   "Set Alpha"
       Enabled         =   True
       Height          =   30.0
-      Left            =   716
+      Left            =   12
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1378,9 +1378,9 @@ Begin iosView BlockanimationView
    Begin iOSSegmentedControl TransitionOptControl
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TransitionOptControl, 3, AnimationOptControl, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TransitionOptControl, 1, AnimationOptControl, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   TransitionOptControl, 7, , 0, False, +1.00, 1, 1, 431, 
-      AutoLayout      =   TransitionOptControl, 3, AnimationOptControl, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TransitionOptControl, 8, , 0, True, +1.00, 1, 1, 29, 
       Caption         =   ""
       Enabled         =   True
@@ -1397,9 +1397,9 @@ Begin iosView BlockanimationView
    Begin iOSButton TestButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TestButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   TestButton, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   TestButton, 2, CenterLabel, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   TestButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   TestButton, 4, TextArea1, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       Caption         =   "Return to Menu"
       Enabled         =   True
@@ -1417,13 +1417,13 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label15
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label15, 2, Transistions, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   Label15, 7, , 0, False, +1.00, 1, 1, 127, 
       AutoLayout      =   Label15, 3, Transistions, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label15, 2, Transistions, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       AutoLayout      =   Label15, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   624
+      Left            =   -80
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Transitions"
@@ -1438,13 +1438,13 @@ Begin iosView BlockanimationView
    Begin iOSSwitch Transistions
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Transistions, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   Transistions, 2, Label4, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-      AutoLayout      =   Transistions, 3, Begincurrent, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Transistions, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Transistions, 2, Label4, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
+      AutoLayout      =   Transistions, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Transistions, 3, Begincurrent, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   759
+      Left            =   55
       LockedInPosition=   False
       Scope           =   0
       Top             =   73
@@ -1455,9 +1455,9 @@ Begin iosView BlockanimationView
    Begin iostextfield ScaleField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScaleField, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   ScaleField, 7, , 0, False, +1.00, 1, 1, 99, 
       AutoLayout      =   ScaleField, 3, Label18, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   ScaleField, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   ScaleField, 8, , 0, False, +1.00, 1, 1, 36, 
       Enabled         =   True
       Height          =   36.0
@@ -1479,14 +1479,14 @@ Begin iosView BlockanimationView
    Begin iOSButton SetScaleButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SetScaleButton, 7, , 0, False, +1.00, 1, 1, 112, 
       AutoLayout      =   SetScaleButton, 3, AAlphaButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetScaleButton, 1, AAlphaButton, 1, False, +1.00, 1, 1, 100, 
-      AutoLayout      =   SetScaleButton, 7, , 0, False, +1.00, 1, 1, 112, 
       AutoLayout      =   SetScaleButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set Scale"
       Enabled         =   True
       Height          =   30.0
-      Left            =   0
+      Left            =   100
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1499,9 +1499,9 @@ Begin iosView BlockanimationView
    Begin iOSLabel Label18
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label18, 1, TestButton, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label18, 7, , 0, False, +1.00, 1, 1, 137, 
       AutoLayout      =   Label18, 3, Alphafield, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Label18, 1, TestButton, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label18, 8, , 0, False, +1.00, 1, 1, 21, 
       Enabled         =   True
       Height          =   21.0
@@ -1520,9 +1520,9 @@ Begin iosView BlockanimationView
    Begin iOSButton AnimateScaleButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AnimateScaleButton, 3, AColorButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AnimateScaleButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AnimateScaleButton, 1, AColorButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   AnimateScaleButton, 3, AColorButton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AnimateScaleButton, 7, , 0, False, +1.00, 1, 1, 81, 
       Caption         =   "An. Scale"
       Enabled         =   True
@@ -1790,7 +1790,7 @@ End
 		  dim velocity as double = double.FromText (VelocityField.text)
 		  
 		  dim newcolor as color = BGColorField.text.ColorFromHex
-		  if Spring.value then 
+		  if Spring.value then
 		    ImageView.AnimateSpring (newcolor, seconds,  dampingRatio, velocity, options, delay)
 		  else
 		    ImageView.Animate (newcolor, seconds,  options, delay, Transistions.value)

--- a/Views/OldAnimationView.xojo_code
+++ b/Views/OldAnimationView.xojo_code
@@ -10,9 +10,9 @@ Begin iosView OldAnimationView
    Begin iOSButton AFrameButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AFrameButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AFrameButton, 7, , 0, False, +1.00, 1, 1, 100, 
       AutoLayout      =   AFrameButton, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   AFrameButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AFrameButton, 4, ARotationButton, 3, False, +1.00, 1, 1, -*kStdControlGapV, 
       Caption         =   "Animate Frame"
       Enabled         =   True
@@ -43,9 +43,9 @@ Begin iosView OldAnimationView
    Begin iostextfield DurationField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DurationField, 1, Label1, 2, False, +1.00, 2, 1, *kStdControlGapH, 
       AutoLayout      =   DurationField, 4, Label4, 4, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DurationField, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   DurationField, 1, Label1, 2, False, +1.00, 2, 1, *kStdControlGapH, 
       AutoLayout      =   DurationField, 7, , 0, False, +1.00, 2, 1, 43, 
       Enabled         =   True
       Height          =   31.0
@@ -67,9 +67,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label1, 7, , 0, False, +1.00, 1, 1, 64, 
       AutoLayout      =   Label1, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label1, 3, TopLayoutGuide, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Label1, 7, , 0, False, +1.00, 1, 1, 64, 
       AutoLayout      =   Label1, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       Enabled         =   True
       Height          =   30.0
@@ -88,9 +88,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label2
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label2, 3, Label1, 4, False, +1.00, 2, 1, *kStdControlGapV, 
       AutoLayout      =   Label2, 1, Label1, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label2, 7, , 0, False, +1.00, 1, 1, 46, 
-      AutoLayout      =   Label2, 3, Label1, 4, False, +1.00, 2, 1, *kStdControlGapV, 
       AutoLayout      =   Label2, 8, , 0, False, +1.00, 1, 1, 21, 
       Enabled         =   True
       Height          =   21.0
@@ -109,9 +109,9 @@ Begin iosView OldAnimationView
    Begin iostextfield FXField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FXField, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   FXField, 7, , 0, False, +1.00, 2, 1, 45, 
       AutoLayout      =   FXField, 3, Label2, 4, False, +1.00, 2, 1, 5, 
-      AutoLayout      =   FXField, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   FXField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -133,9 +133,9 @@ Begin iosView OldAnimationView
    Begin iostextfield FYField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FYField, 1, FXField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FYField, 3, FXField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   FYField, 2, FXField, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   FYField, 1, FXField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FYField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -157,9 +157,9 @@ Begin iosView OldAnimationView
    Begin iostextfield FWField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FWField, 1, FYField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FWField, 3, FYField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   FWField, 2, FYField, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   FWField, 1, FYField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FWField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -181,9 +181,9 @@ Begin iosView OldAnimationView
    Begin iostextfield FHField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   FHField, 2, FWField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FHField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   FHField, 3, FWField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   FHField, 2, FWField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   FHField, 1, FWField, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
@@ -205,9 +205,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label3, 3, Label2, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   Label3, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label3, 1, Label2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Label3, 3, Label2, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   Label3, 7, , 0, False, +1.00, 1, 1, 58, 
       Enabled         =   True
       Height          =   21.0
@@ -226,9 +226,9 @@ Begin iosView OldAnimationView
    Begin iostextfield BHField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BHField, 2, BWField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BHField, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   BHField, 3, FHField, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BHField, 2, BWField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BHField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -250,9 +250,9 @@ Begin iosView OldAnimationView
    Begin iostextfield BWField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BWField, 2, BYField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BWField, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   BWField, 3, FWField, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BWField, 2, BYField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BWField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -274,9 +274,9 @@ Begin iosView OldAnimationView
    Begin iostextfield BXField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BXField, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   BXField, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   BXField, 3, FXField, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BXField, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   BXField, 1, Label3, 1, False, +1.00, 2, 1, 0, 
       Enabled         =   True
       Height          =   31.0
@@ -298,9 +298,9 @@ Begin iosView OldAnimationView
    Begin iostextfield BYField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BYField, 2, BXField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BYField, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   BYField, 3, FYField, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BYField, 2, BXField, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BYField, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -322,9 +322,9 @@ Begin iosView OldAnimationView
    Begin iOSButton ABoundsButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ABoundsButton, 1, AFrameButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ABoundsButton, 7, , 0, False, +1.00, 1, 1, 114, 
       AutoLayout      =   ABoundsButton, 3, AFrameButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ABoundsButton, 1, AFrameButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ABoundsButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Animate Bounds"
       Enabled         =   True
@@ -342,13 +342,13 @@ Begin iosView OldAnimationView
    Begin iOSSwitch Begincurrent
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Begincurrent, 2, <Parent>, 2, False, +1.00, 1, 1, -*kStdGapCtlToViewH, 
-      AutoLayout      =   Begincurrent, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Begincurrent, 3, Label1, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Begincurrent, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Begincurrent, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Begincurrent, 2, <Parent>, 2, False, +1.00, 1, 1, -*kStdGapCtlToViewH, 
+      AutoLayout      =   Begincurrent, 3, Label1, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   697
+      Left            =   249
       LockedInPosition=   False
       Scope           =   0
       Top             =   73
@@ -359,13 +359,13 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label4
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label4, 7, , 0, False, +1.00, 1, 1, 127, 
       AutoLayout      =   Label4, 4, Label3, 3, False, +1.00, 1, 1, -*kStdControlGapV, 
       AutoLayout      =   Label4, 3, Begincurrent, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label4, 7, , 0, False, +1.00, 1, 1, 127, 
       AutoLayout      =   Label4, 2, Begincurrent, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   562
+      Left            =   114
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Begin from current"
@@ -380,13 +380,13 @@ Begin iosView OldAnimationView
    Begin iOSSwitch AutoReverse
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   AutoReverse, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   AutoReverse, 3, RepeatField, 4, False, +1.00, 2, 1, *kStdControlGapV, 
-      AutoLayout      =   AutoReverse, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   AutoReverse, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   AutoReverse, 3, RepeatField, 4, False, +1.00, 2, 1, *kStdControlGapV, 
+      AutoLayout      =   AutoReverse, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   AutoReverse, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   697
+      Left            =   249
       LockedInPosition=   False
       Scope           =   0
       Top             =   151
@@ -397,13 +397,13 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label6
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label6, 3, AutoReverse, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label6, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label6, 2, AutoReverse, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label6, 3, AutoReverse, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label6, 7, , 0, False, +1.00, 1, 1, 163, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   526
+      Left            =   78
       LockedInPosition=   False
       Scope           =   0
       Text            =   "AutoReverse"
@@ -418,14 +418,14 @@ Begin iosView OldAnimationView
    Begin iOSButton SBoundsButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SBoundsButton, 7, , 0, False, +1.00, 1, 1, 86, 
       AutoLayout      =   SBoundsButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SBoundsButton, 3, ABoundsButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   SBoundsButton, 7, , 0, False, +1.00, 1, 1, 86, 
       AutoLayout      =   SBoundsButton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       Caption         =   "Set Bounds"
       Enabled         =   True
       Height          =   30.0
-      Left            =   662
+      Left            =   214
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -438,14 +438,14 @@ Begin iosView OldAnimationView
    Begin iOSButton SFrameButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SFrameButton, 2, SBoundsButton, 1, False, +1.00, 4, 1, -16, 
       AutoLayout      =   SFrameButton, 7, , 0, False, +1.00, 1, 1, 73, 
       AutoLayout      =   SFrameButton, 3, SBoundsButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   SFrameButton, 2, SBoundsButton, 1, False, +1.00, 4, 1, -16, 
       AutoLayout      =   SFrameButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set Frame"
       Enabled         =   True
       Height          =   30.0
-      Left            =   573
+      Left            =   125
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -458,9 +458,9 @@ Begin iosView OldAnimationView
    Begin iOSSegmentedControl AnimationOptControl
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AnimationOptControl, 1, <Parent>, 1, False, +1.00, 2, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   AnimationOptControl, 4, SFrameButton, 3, False, +1.00, 1, 1, -*kStdControlGapV, 
       AutoLayout      =   AnimationOptControl, 8, , 0, True, +1.00, 1, 1, 29, 
-      AutoLayout      =   AnimationOptControl, 1, <Parent>, 1, False, +1.00, 2, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   AnimationOptControl, 7, , 0, False, +1.00, 1, 1, 215, 
       Caption         =   ""
       Enabled         =   True
@@ -477,9 +477,9 @@ Begin iosView OldAnimationView
    Begin ioslabel TextArea1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TextArea1, 2, SBoundsButton, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TextArea1, 8, , 0, False, +1.00, 2, 1, 97, 
       AutoLayout      =   TextArea1, 4, AnimationOptControl, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
-      AutoLayout      =   TextArea1, 2, SBoundsButton, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TextArea1, 1, AnimationOptControl, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   False
       Height          =   97.0
@@ -493,18 +493,18 @@ Begin iosView OldAnimationView
       TextSize        =   0
       Top             =   262
       Visible         =   True
-      Width           =   728.0
+      Width           =   280.0
       Begin iostextfield TrF0
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   TrF0, 3, BeginFromTransform, 4, False, +1.00, 2, 1, 40, 
          AutoLayout      =   TrF0, 8, , 0, False, +1.00, 1, 1, 31, 
          AutoLayout      =   TrF0, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
-         AutoLayout      =   TrF0, 3, BeginFromTransform, 4, False, +1.00, 2, 1, 40, 
          AutoLayout      =   TrF0, 7, , 0, False, +1.00, 1, 1, 45, 
          Enabled         =   False
          Height          =   31.0
          KeyboardType    =   "2"
-         Left            =   703
+         Left            =   255
          LockedInPosition=   False
          PanelIndex      =   0
          Parent          =   "TextArea1"
@@ -523,14 +523,14 @@ Begin iosView OldAnimationView
       Begin iostextfield TRFB
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   TRFB, 2, TrF0, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
          AutoLayout      =   TRFB, 7, , 0, False, +1.00, 1, 1, 79, 
          AutoLayout      =   TRFB, 3, TrF0, 3, False, +1.00, 1, 1, 0, 
-         AutoLayout      =   TRFB, 2, TrF0, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
          AutoLayout      =   TRFB, 8, , 0, False, +1.00, 2, 1, 31, 
          Enabled         =   False
          Height          =   31.0
          KeyboardType    =   "2"
-         Left            =   616
+         Left            =   168
          LockedInPosition=   False
          PanelIndex      =   0
          Parent          =   "TextArea1"
@@ -549,14 +549,14 @@ Begin iosView OldAnimationView
       Begin iostextfield TRFA
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   TRFA, 7, , 0, False, +1.00, 1, 1, 79, 
          AutoLayout      =   TRFA, 8, , 0, False, +1.00, 1, 1, 31, 
          AutoLayout      =   TRFA, 3, TRFB, 3, False, +1.00, 1, 1, 0, 
-         AutoLayout      =   TRFA, 7, , 0, False, +1.00, 1, 1, 79, 
          AutoLayout      =   TRFA, 2, TRFB, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
          Enabled         =   False
          Height          =   31.0
          KeyboardType    =   "2"
-         Left            =   529
+         Left            =   81
          LockedInPosition=   False
          PanelIndex      =   0
          Parent          =   "TextArea1"
@@ -576,13 +576,13 @@ Begin iosView OldAnimationView
    Begin iOSLabel AnimationEndedLabel
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AnimationEndedLabel, 9, <Parent>, 9, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AnimationEndedLabel, 7, , 0, False, +1.00, 2, 1, 250, 
       AutoLayout      =   AnimationEndedLabel, 8, , 0, False, +1.00, 1, 1, 30, 
-      AutoLayout      =   AnimationEndedLabel, 9, <Parent>, 9, False, +1.00, 1, 1, 0, 
       AutoLayout      =   AnimationEndedLabel, 4, TextArea1, 4, False, +1.00, 2, 1, -*kStdControlGapV, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   259
+      Left            =   35
       LockedInPosition=   False
       Scope           =   0
       Text            =   ""
@@ -597,9 +597,9 @@ Begin iosView OldAnimationView
    Begin uitextfield BGColorField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   BGColorField, 1, TextArea1, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BGColorField, 3, Label7, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   BGColorField, 2, BHField, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   BGColorField, 1, TextArea1, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   BGColorField, 8, , 0, False, +1.00, 1, 1, 36, 
       Enabled         =   True
       Height          =   36.0
@@ -621,9 +621,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label7
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label7, 1, BGColorField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label7, 7, , 0, False, +1.00, 1, 1, 137, 
       AutoLayout      =   Label7, 3, BHField, 4, False, +1.00, 2, 1, *kStdControlGapV, 
-      AutoLayout      =   Label7, 1, BGColorField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label7, 8, , 0, False, +1.00, 1, 1, 21, 
       Enabled         =   True
       Height          =   21.0
@@ -642,14 +642,14 @@ Begin iosView OldAnimationView
    Begin iOSButton SFrameButton1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SFrameButton1, 2, SFrameButton, 1, False, +1.00, 4, 1, -*kStdControlGapH, 
       AutoLayout      =   SFrameButton1, 7, , 0, False, +1.00, 1, 1, 92, 
       AutoLayout      =   SFrameButton1, 3, SFrameButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   SFrameButton1, 2, SFrameButton, 1, False, +1.00, 4, 1, -*kStdControlGapH, 
       AutoLayout      =   SFrameButton1, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set BGColor"
       Enabled         =   True
       Height          =   30.0
-      Left            =   473
+      Left            =   25
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -662,9 +662,9 @@ Begin iosView OldAnimationView
    Begin iOSButton AColorButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AColorButton, 7, , 0, False, +1.00, 1, 1, 119, 
       AutoLayout      =   AColorButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AColorButton, 3, ABoundsButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   AColorButton, 7, , 0, False, +1.00, 1, 1, 119, 
       AutoLayout      =   AColorButton, 1, ABoundsButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Caption         =   "Animate BGColor"
       Enabled         =   True
@@ -682,13 +682,13 @@ Begin iosView OldAnimationView
    Begin iOSSwitch BeginFromTransform
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   BeginFromTransform, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   BeginFromTransform, 2, AutoReverse, 2, False, +1.00, 2, 1, 0, 
-      AutoLayout      =   BeginFromTransform, 3, AutoReverse, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   BeginFromTransform, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   BeginFromTransform, 2, AutoReverse, 2, False, +1.00, 2, 1, 0, 
+      AutoLayout      =   BeginFromTransform, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   BeginFromTransform, 3, AutoReverse, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   697
+      Left            =   249
       LockedInPosition=   False
       Scope           =   0
       Top             =   190
@@ -699,8 +699,8 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label8
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Label8, 3, BeginFromTransform, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label8, 2, BeginFromTransform, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
+      AutoLayout      =   Label8, 3, BeginFromTransform, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label8, 8, , 0, False, +1.00, 2, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -714,18 +714,18 @@ Begin iosView OldAnimationView
       TextSize        =   0
       Top             =   190
       Visible         =   True
-      Width           =   -27.0
+      Width           =   -475.0
    End
    Begin iOSLabel Label9
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label9, 3, RepeatField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label9, 8, , 0, False, +1.00, 2, 1, 30, 
       AutoLayout      =   Label9, 2, RepeatField, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label9, 3, RepeatField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label9, 7, , 0, False, +1.00, 1, 1, 54, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   643
+      Left            =   195
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Repeat"
@@ -740,15 +740,15 @@ Begin iosView OldAnimationView
    Begin iostextfield RepeatField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   RepeatField, 8, , 0, False, +1.00, 1, 1, 31, 
-      AutoLayout      =   RepeatField, 1, Label9, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   RepeatField, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   RepeatField, 3, Begincurrent, 4, False, +1.00, 1, 1, *kStdControlGapV, 
+      AutoLayout      =   RepeatField, 1, Label9, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   RepeatField, 8, , 0, False, +1.00, 1, 1, 31, 
+      AutoLayout      =   RepeatField, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   RepeatField, 7, , 0, False, +1.00, 1, 1, 43, 
       Enabled         =   True
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   705
+      Left            =   257
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "sec."
@@ -765,14 +765,14 @@ Begin iosView OldAnimationView
    Begin iOSButton ResetButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ResetButton, 7, , 0, False, +1.00, 1, 1, 67, 
       AutoLayout      =   ResetButton, 4, SBoundsButton, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       AutoLayout      =   ResetButton, 8, , 0, False, +1.00, 1, 1, 30, 
-      AutoLayout      =   ResetButton, 7, , 0, False, +1.00, 1, 1, 67, 
       AutoLayout      =   ResetButton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       Caption         =   "Reset"
       Enabled         =   True
       Height          =   30.0
-      Left            =   681
+      Left            =   233
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -785,9 +785,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label12
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label12, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Label12, 7, , 0, False, +1.00, 1, 1, 137, 
       AutoLayout      =   Label12, 3, BGColorField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Label12, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Label12, 8, , 0, False, +1.00, 1, 1, 21, 
       Enabled         =   True
       Height          =   21.0
@@ -806,9 +806,9 @@ Begin iosView OldAnimationView
    Begin uitextfield RotationField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   RotationField, 7, , 0, False, +1.00, 1, 1, 99, 
       AutoLayout      =   RotationField, 8, , 0, False, +1.00, 1, 1, 36, 
       AutoLayout      =   RotationField, 3, Label12, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   RotationField, 7, , 0, False, +1.00, 1, 1, 99, 
       AutoLayout      =   RotationField, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       Enabled         =   True
       Height          =   36.0
@@ -830,13 +830,13 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label13
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label13, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label13, 7, , 0, False, +1.00, 1, 1, 137, 
       AutoLayout      =   Label13, 1, TRFA, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label13, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label13, 4, TRFA, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       Enabled         =   True
       Height          =   21.0
-      Left            =   529
+      Left            =   81
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Transformation"
@@ -851,9 +851,9 @@ Begin iosView OldAnimationView
    Begin iOSButton ARotationButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ARotationButton, 2, Label3, 2, False, +1.00, 2, 1, 0, 
       AutoLayout      =   ARotationButton, 4, BottomLayoutGuide, 3, False, +1.00, 4, 1, -*kStdControlGapV, 
       AutoLayout      =   ARotationButton, 8, , 0, False, +1.00, 1, 1, 30, 
-      AutoLayout      =   ARotationButton, 2, Label3, 2, False, +1.00, 2, 1, 0, 
       AutoLayout      =   ARotationButton, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       Caption         =   "Animate Rotation"
       Enabled         =   True
@@ -871,14 +871,14 @@ Begin iosView OldAnimationView
    Begin iostextfield TrF01
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrF01, 1, TrF0, 1, False, +1.00, 2, 1, 0, 
       AutoLayout      =   TrF01, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   TrF01, 3, TrF0, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   TrF01, 1, TrF0, 1, False, +1.00, 2, 1, 0, 
       AutoLayout      =   TrF01, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   703
+      Left            =   255
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "0"
@@ -895,14 +895,14 @@ Begin iosView OldAnimationView
    Begin iostextfield TrF1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrF1, 1, TrFTY, 2, False, +1.00, 2, 1, *kStdControlGapH, 
       AutoLayout      =   TrF1, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   TrF1, 3, TrF01, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   TrF1, 1, TrFTY, 2, False, +1.00, 2, 1, *kStdControlGapH, 
       AutoLayout      =   TrF1, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   703
+      Left            =   255
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "1"
@@ -919,14 +919,14 @@ Begin iosView OldAnimationView
    Begin iostextfield TrFTY
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFTY, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFTY, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   TrFTY, 3, TrF1, 3, False, +1.00, 1, 1, 1, 
-      AutoLayout      =   TrFTY, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFTY, 1, TrFD, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   616
+      Left            =   168
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "1"
@@ -943,14 +943,14 @@ Begin iosView OldAnimationView
    Begin iostextfield TrFD
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFD, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFD, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   TrFD, 3, TrF01, 3, False, +1.00, 1, 1, 1, 
-      AutoLayout      =   TrFD, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFD, 2, TrF01, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   616
+      Left            =   168
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "0"
@@ -967,14 +967,14 @@ Begin iosView OldAnimationView
    Begin iostextfield TrFC
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFC, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFC, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   TrFC, 3, TRFA, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   TrFC, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFC, 2, TRFA, 2, False, +1.00, 2, 1, 0, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   529
+      Left            =   81
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "0"
@@ -991,14 +991,14 @@ Begin iosView OldAnimationView
    Begin iostextfield TrFTX
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TrFTX, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFTX, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   TrFTX, 3, TrFC, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   TrFTX, 7, , 0, False, +1.00, 1, 1, 79, 
       AutoLayout      =   TrFTX, 1, TrFC, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   False
       Height          =   31.0
       KeyboardType    =   "2"
-      Left            =   529
+      Left            =   81
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "1"
@@ -1015,14 +1015,14 @@ Begin iosView OldAnimationView
    Begin iOSButton Setrotationbutton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Setrotationbutton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   Setrotationbutton, 7, , 0, False, +1.00, 2, 1, 90, 
       AutoLayout      =   Setrotationbutton, 3, ARotationButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Setrotationbutton, 2, <Parent>, 2, False, +1.00, 2, 1, -*kStdGapCtlToViewH, 
       AutoLayout      =   Setrotationbutton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set Rotation"
       Enabled         =   True
       Height          =   30.0
-      Left            =   658
+      Left            =   210
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1035,9 +1035,9 @@ Begin iosView OldAnimationView
    Begin iostextfield CXField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   CXField, 1, BXField, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   CXField, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   CXField, 3, BXField, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   CXField, 1, BXField, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   CXField, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -1059,9 +1059,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel CenterLabel
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   CenterLabel, 1, CXField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CenterLabel, 7, , 0, False, +1.00, 1, 1, 58, 
       AutoLayout      =   CenterLabel, 3, Label3, 3, False, +1.00, 2, 1, 0, 
-      AutoLayout      =   CenterLabel, 1, CXField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CenterLabel, 8, , 0, False, +1.00, 1, 1, 21, 
       Enabled         =   True
       Height          =   21.0
@@ -1080,9 +1080,9 @@ Begin iosView OldAnimationView
    Begin iostextfield CYField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   CYField, 1, CXField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CYField, 7, , 0, False, +1.00, 1, 1, 45, 
       AutoLayout      =   CYField, 3, BYField, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   CYField, 1, CXField, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   CYField, 8, , 0, False, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -1104,14 +1104,14 @@ Begin iosView OldAnimationView
    Begin iOSButton SetCenterbutton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SetCenterbutton, 3, Setrotationbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetCenterbutton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SetCenterbutton, 2, Setrotationbutton, 1, False, +1.00, 3, 1, -*kStdControlGapH, 
-      AutoLayout      =   SetCenterbutton, 3, Setrotationbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetCenterbutton, 7, , 0, False, +1.00, 1, 1, 86, 
       Caption         =   "Set Center"
       Enabled         =   True
       Height          =   30.0
-      Left            =   564
+      Left            =   116
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1124,9 +1124,9 @@ Begin iosView OldAnimationView
    Begin iOSButton ACenterButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ACenterButton, 1, ARotationButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ACenterButton, 7, , 0, False, +1.00, 1, 1, 112, 
       AutoLayout      =   ACenterButton, 3, ARotationButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ACenterButton, 1, ARotationButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ACenterButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Animate Center"
       Enabled         =   True
@@ -1144,9 +1144,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label14
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label14, 3, RotationField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label14, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label14, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   Label14, 3, RotationField, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label14, 7, , 0, False, +1.00, 1, 1, 137, 
       Enabled         =   True
       Height          =   21.0
@@ -1164,9 +1164,9 @@ Begin iosView OldAnimationView
       Begin iOSLabel Label17
          AccessibilityHint=   ""
          AccessibilityLabel=   ""
+         AutoLayout      =   Label17, 1, Label14, 1, False, +1.00, 1, 1, 0, 
          AutoLayout      =   Label17, 8, , 0, False, +1.00, 1, 1, 21, 
          AutoLayout      =   Label17, 7, , 0, False, +1.00, 1, 1, 137, 
-         AutoLayout      =   Label17, 1, Label14, 1, False, +1.00, 1, 1, 0, 
          AutoLayout      =   Label17, 3, Label14, 3, False, +1.00, 1, 1, 0, 
          Enabled         =   True
          Height          =   21.0
@@ -1188,9 +1188,9 @@ Begin iosView OldAnimationView
    Begin iostextfield Alphafield
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Alphafield, 3, Label14, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Alphafield, 8, , 0, False, +1.00, 1, 1, 36, 
       AutoLayout      =   Alphafield, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   Alphafield, 3, Label14, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Alphafield, 7, , 0, False, +1.00, 1, 1, 99, 
       Enabled         =   True
       Height          =   36.0
@@ -1212,9 +1212,9 @@ Begin iosView OldAnimationView
    Begin iOSButton AAlphaButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AAlphaButton, 7, , 0, False, +1.00, 1, 1, 94, 
       AutoLayout      =   AAlphaButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   AAlphaButton, 3, ACenterButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   AAlphaButton, 7, , 0, False, +1.00, 1, 1, 94, 
       AutoLayout      =   AAlphaButton, 1, ACenterButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Caption         =   "Animate Alpha"
       Enabled         =   True
@@ -1232,14 +1232,14 @@ Begin iosView OldAnimationView
    Begin iOSButton SetAlphaButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SetAlphaButton, 3, SetCenterbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetAlphaButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SetAlphaButton, 1, SetScaleButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   SetAlphaButton, 3, SetCenterbutton, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   SetAlphaButton, 7, , 0, False, +1.00, 1, 1, 86, 
       Caption         =   "Set Alpha"
       Enabled         =   True
       Height          =   30.0
-      Left            =   473
+      Left            =   25
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -1252,9 +1252,9 @@ Begin iosView OldAnimationView
    Begin iOSSegmentedControl TransitionOptControl
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TransitionOptControl, 7, , 0, False, +1.00, 1, 1, 431, 
       AutoLayout      =   TransitionOptControl, 8, , 0, True, +1.00, 1, 1, 29, 
       AutoLayout      =   TransitionOptControl, 3, AnimationOptControl, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   TransitionOptControl, 7, , 0, False, +1.00, 1, 1, 431, 
       AutoLayout      =   TransitionOptControl, 1, AnimationOptControl, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Caption         =   ""
       Enabled         =   True
@@ -1271,9 +1271,9 @@ Begin iosView OldAnimationView
    Begin iOSButton TestButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TestButton, 2, CenterLabel, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TestButton, 4, TextArea1, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       AutoLayout      =   TestButton, 8, , 0, False, +1.00, 1, 1, 30, 
-      AutoLayout      =   TestButton, 2, CenterLabel, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TestButton, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       Caption         =   "Return to Menu"
       Enabled         =   True
@@ -1291,9 +1291,9 @@ Begin iosView OldAnimationView
    Begin iostextfield ScaleField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScaleField, 3, Label18, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   ScaleField, 8, , 0, False, +1.00, 1, 1, 36, 
       AutoLayout      =   ScaleField, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
-      AutoLayout      =   ScaleField, 3, Label18, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   ScaleField, 7, , 0, False, +1.00, 1, 1, 99, 
       Enabled         =   True
       Height          =   36.0
@@ -1315,9 +1315,9 @@ Begin iosView OldAnimationView
    Begin iOSButton SetScaleButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   SetScaleButton, 2, SFrameButton1, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   SetScaleButton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   SetScaleButton, 3, AAlphaButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   SetScaleButton, 2, SFrameButton1, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   SetScaleButton, 1, AnimateScaleButton, 1, False, +1.00, 1, 1, 0, 
       Caption         =   "Set Scale"
       Enabled         =   True
@@ -1330,14 +1330,14 @@ Begin iosView OldAnimationView
       TextSize        =   0
       Top             =   442
       Visible         =   True
-      Width           =   88.0
+      Width           =   -360.0
    End
    Begin iOSLabel Label18
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label18, 3, Alphafield, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label18, 8, , 0, False, +1.00, 1, 1, 21, 
       AutoLayout      =   Label18, 1, TestButton, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label18, 3, Alphafield, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label18, 7, , 0, False, +1.00, 1, 1, 137, 
       Enabled         =   True
       Height          =   21.0
@@ -1356,9 +1356,9 @@ Begin iosView OldAnimationView
    Begin iOSButton AnimateScaleButton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   AnimateScaleButton, 1, AColorButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   AnimateScaleButton, 7, , 0, False, +1.00, 1, 1, 81, 
       AutoLayout      =   AnimateScaleButton, 3, AColorButton, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   AnimateScaleButton, 1, AColorButton, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   AnimateScaleButton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "An. Scale"
       Enabled         =   True
@@ -1376,9 +1376,9 @@ Begin iosView OldAnimationView
    Begin iostextfield DelayField
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DelayField, 3, Label10, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DelayField, 8, , 0, False, +1.00, 1, 1, 31, 
       AutoLayout      =   DelayField, 1, Label10, 2, False, +1.00, 4, 1, *kStdControlGapH, 
-      AutoLayout      =   DelayField, 3, Label10, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DelayField, 7, , 0, False, +1.00, 4, 1, 43, 
       Enabled         =   True
       Height          =   31.0
@@ -1400,9 +1400,9 @@ Begin iosView OldAnimationView
    Begin iOSLabel Label10
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label10, 3, DurationField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label10, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label10, 1, DurationField, 2, False, +1.00, 4, 1, *kStdControlGapH, 
-      AutoLayout      =   Label10, 3, DurationField, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label10, 7, , 0, False, +1.00, 2, 1, 80, 
       Enabled         =   True
       Height          =   30.0
@@ -1474,7 +1474,7 @@ End
 		  // false, false, false, false, false, AnimationOptionValue)
 		  // options = options or TransitionOptionValue
 		  // // dim delay as double = double.FromText (DelayField.text)
-		  // 
+		  //
 		  // // ImageView.AnimateResetTransformation seconds, options, delay, Transistions.value
 		  
 		End Sub
@@ -1684,7 +1684,7 @@ End
 #tag Events AColorButton
 	#tag Event
 		Sub Action()
-		   dim newcolor as color = BGColorField.text.ColorFromHex
+		  dim newcolor as color = BGColorField.text.ColorFromHex
 		  dim seconds as double = double.FromText (DurationField.text)
 		  dim repeat as double = double.FromText (RepeatField.text)
 		  dim delay as double = double.FromText (DelayField.text)

--- a/Views/TableView.xojo_code
+++ b/Views/TableView.xojo_code
@@ -10,9 +10,9 @@ Begin iosView TableView
    Begin iOSLabel Label3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label3, 3, <Parent>, 3, False, +1.00, 1, 1, 91, 
       AutoLayout      =   Label3, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   Label3, 2, <Parent>, 2, False, +1.00, 1, 1, -*kStdGapCtlToViewH, 
-      AutoLayout      =   Label3, 3, <Parent>, 3, False, +1.00, 1, 1, 91, 
       AutoLayout      =   Label3, 8, , 0, False, +1.00, 1, 1, 58, 
       Enabled         =   True
       Height          =   58.0
@@ -26,14 +26,14 @@ Begin iosView TableView
       TextSize        =   0
       Top             =   91
       Visible         =   True
-      Width           =   728.0
+      Width           =   280.0
    End
    Begin iOSButton Button1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button1, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button1, 7, , 0, False, +1.00, 1, 1, 141, 
       AutoLayout      =   Button1, 1, <Parent>, 1, False, +1.00, 2, 1, 20, 
-      AutoLayout      =   Button1, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button1, 4, BottomLayoutGuide, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       Caption         =   "Return to menu"
       Enabled         =   True
@@ -51,32 +51,27 @@ Begin iosView TableView
    Begin iostable TextArea1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   TextArea1, 8, , 0, False, +1.00, 1, 1, 336, 
-      AutoLayout      =   TextArea1, 3, <Parent>, 3, False, +1.00, 1, 1, 147, 
-      AutoLayout      =   TextArea1, 2, Label3, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TextArea1, 1, Label3, 1, False, +1.00, 1, 1, 0, 
-      Editable        =   True
+      AutoLayout      =   TextArea1, 3, <Parent>, 3, False, +1.00, 1, 1, 147, 
+      AutoLayout      =   TextArea1, 8, , 0, False, +1.00, 1, 1, 336, 
+      AutoLayout      =   TextArea1, 2, Label3, 2, False, +1.00, 1, 1, 0, 
+      Format          =   ""
       Height          =   336.0
-      KeyboardType    =   "0"
       Left            =   20
       LockedInPosition=   False
       Scope           =   0
-      Text            =   ""
-      TextAlignment   =   "0"
-      TextColor       =   &c00000000
-      TextFont        =   ""
-      TextSize        =   0
+      SectionCount    =   0
       Top             =   147
       Visible         =   True
-      Width           =   728.0
+      Width           =   280.0
    End
    Begin iOSSwitch Switch1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch1, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   Switch1, 1, TextArea1, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Switch1, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
       AutoLayout      =   Switch1, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch1, 1, TextArea1, 1, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Switch1, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch1, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
       Enabled         =   True
       Height          =   31.0
       Left            =   20
@@ -90,9 +85,9 @@ Begin iosView TableView
    Begin iOSLabel Label1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label1, 3, Switch1, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label1, 1, Switch1, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label1, 7, , 0, False, +1.00, 2, 1, 110, 
-      AutoLayout      =   Label1, 3, Switch1, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label1, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -111,13 +106,13 @@ Begin iosView TableView
    Begin iOSLabel Label4
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label4, 3, Switch2, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label4, 1, Switch2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label4, 2, Label9, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label4, 3, Switch2, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label4, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   443
+      Left            =   219
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Bounces Zoom"
@@ -127,18 +122,18 @@ Begin iosView TableView
       TextSize        =   0
       Top             =   523
       Visible         =   True
-      Width           =   117.0
+      Width           =   341.0
    End
    Begin iOSSwitch Switch2
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch2, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   Switch2, 1, TextArea1, 9, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Switch2, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
       AutoLayout      =   Switch2, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch2, 1, TextArea1, 9, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Switch2, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch2, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   384
+      Left            =   160
       LockedInPosition=   False
       Scope           =   0
       Top             =   523
@@ -149,9 +144,9 @@ Begin iosView TableView
    Begin iOSTextField ContentOffsetX
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentOffsetX, 3, Label5, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentOffsetX, 1, Label5, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentOffsetX, 7, , 0, False, +1.00, 1, 1, 91, 
-      AutoLayout      =   ContentOffsetX, 3, Label5, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentOffsetX, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -173,9 +168,9 @@ Begin iosView TableView
    Begin iOSLabel Label5
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label5, 3, Switch1, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label5, 1, Switch1, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label5, 7, , 0, False, +1.00, 1, 1, 148, 
-      AutoLayout      =   Label5, 3, Switch1, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label5, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -194,9 +189,9 @@ Begin iosView TableView
    Begin iOSTextField ContentOffsetY
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentOffsetY, 3, Label5, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentOffsetY, 1, ContentOffsetX, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentOffsetY, 7, , 0, False, +1.00, 1, 1, 91, 
-      AutoLayout      =   ContentOffsetY, 3, Label5, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentOffsetY, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -218,14 +213,14 @@ Begin iosView TableView
    Begin iOSButton Button2
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button2, 7, , 0, False, +1.00, 1, 1, 100, 
       AutoLayout      =   Button2, 4, Label5, 4, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button2, 3, ContentOffsetY, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Button2, 7, , 0, False, +1.00, 1, 1, 100, 
       AutoLayout      =   Button2, 1, Switch2, 1, False, +1.00, 1, 1, 0, 
       Caption         =   "Set"
       Enabled         =   True
       Height          =   30.0
-      Left            =   384
+      Left            =   160
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -238,13 +233,13 @@ Begin iosView TableView
    Begin iOSSwitch animatedSwitch
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   animatedSwitch, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   animatedSwitch, 3, ContentOffsetX, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   animatedSwitch, 1, Button2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   animatedSwitch, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   animatedSwitch, 3, ContentOffsetX, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   animatedSwitch, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   animatedSwitch, 1, Button2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   492
+      Left            =   268
       LockedInPosition=   False
       Scope           =   0
       Top             =   562
@@ -255,13 +250,13 @@ Begin iosView TableView
    Begin iOSLabel Label6
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label6, 1, animatedSwitch, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label6, 3, Switch1, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label6, 2, TextArea1, 2, False, +1.00, 1, 1, -103, 
-      AutoLayout      =   Label6, 1, animatedSwitch, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label6, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   551
+      Left            =   327
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Animated"
@@ -271,14 +266,14 @@ Begin iosView TableView
       TextSize        =   0
       Top             =   562
       Visible         =   True
-      Width           =   94.0
+      Width           =   -130.0
    End
    Begin iOSLabel Label7
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label7, 2, ContentOffsetY, 1, False, +1.00, 2, 1, 2, 
       AutoLayout      =   Label7, 4, ContentinsetTop, 4, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label7, 3, animatedSwitch, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Label7, 2, ContentOffsetY, 1, False, +1.00, 2, 1, 2, 
       AutoLayout      =   Label7, 1, Switch1, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
@@ -297,9 +292,9 @@ Begin iosView TableView
    Begin iOSTextField ContentinsetTop
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentinsetTop, 1, Label7, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentinsetTop, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentinsetTop, 3, Label7, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentinsetTop, 1, Label7, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentinsetTop, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -321,9 +316,9 @@ Begin iosView TableView
    Begin iOSTextField ContentInsetLeft
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentInsetLeft, 3, ContentinsetTop, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentInsetLeft, 1, ContentinsetTop, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentInsetLeft, 7, , 0, False, +1.00, 1, 1, 91, 
-      AutoLayout      =   ContentInsetLeft, 3, ContentinsetTop, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentInsetLeft, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -345,9 +340,9 @@ Begin iosView TableView
    Begin iOSTextField ContentInsetBottom
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentInsetBottom, 3, ContentinsetTop, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentInsetBottom, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentInsetBottom, 1, ContentInsetLeft, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ContentInsetBottom, 3, ContentinsetTop, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentInsetBottom, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -369,9 +364,9 @@ Begin iosView TableView
    Begin iOSTextField ContentInsetRight
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentInsetRight, 1, ContentInsetBottom, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentInsetRight, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentInsetRight, 3, ContentInsetBottom, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentInsetRight, 1, ContentInsetBottom, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentInsetRight, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -393,9 +388,9 @@ Begin iosView TableView
    Begin iOSButton Button3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button3, 3, ContentInsetRight, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button3, 1, ContentInsetRight, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button3, 7, , 0, False, +1.00, 1, 1, 64, 
-      AutoLayout      =   Button3, 3, ContentInsetRight, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button3, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set"
       Enabled         =   True
@@ -413,14 +408,14 @@ Begin iosView TableView
    Begin iOSButton Button5
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button5, 3, Label6, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button5, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button5, 1, Label6, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Button5, 3, Label6, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button5, 7, , 0, False, +1.00, 1, 1, 64, 
       Caption         =   "Refresh"
       Enabled         =   True
       Height          =   30.0
-      Left            =   653
+      Left            =   205
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -433,10 +428,10 @@ Begin iosView TableView
    Begin iOSSwitch Switch3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch3, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   Switch3, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   Switch3, 3, Label7, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Switch3, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch3, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
+      AutoLayout      =   Switch3, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch3, 3, Label7, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   31.0
       Left            =   20
@@ -450,9 +445,9 @@ Begin iosView TableView
    Begin iOSLabel Label8
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label8, 7, , 0, False, +1.00, 1, 1, 422, 
       AutoLayout      =   Label8, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label8, 3, Switch3, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label8, 7, , 0, False, +1.00, 1, 1, 422, 
       AutoLayout      =   Label8, 1, Switch3, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   30.0
@@ -471,10 +466,10 @@ Begin iosView TableView
    Begin iOSSwitch DirectionalSwitch
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   DirectionalSwitch, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   DirectionalSwitch, 1, Label8, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   DirectionalSwitch, 3, Label8, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DirectionalSwitch, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   DirectionalSwitch, 1, Label8, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   DirectionalSwitch, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   DirectionalSwitch, 3, Label8, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
       Left            =   509
@@ -488,8 +483,8 @@ Begin iosView TableView
    Begin iOSLabel Label9
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Label9, 3, DirectionalSwitch, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label9, 1, DirectionalSwitch, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   Label9, 3, DirectionalSwitch, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label9, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -508,9 +503,9 @@ Begin iosView TableView
    Begin iOSTextField ScrollRectLeft
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScrollRectLeft, 1, Scrollbutton, 2, False, +1.00, 2, 1, *kStdControlGapH, 
       AutoLayout      =   ScrollRectLeft, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ScrollRectLeft, 3, Scrollbutton, 3, False, +1.00, 2, 1, 0, 
-      AutoLayout      =   ScrollRectLeft, 1, Scrollbutton, 2, False, +1.00, 2, 1, *kStdControlGapH, 
       AutoLayout      =   ScrollRectLeft, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -532,9 +527,9 @@ Begin iosView TableView
    Begin iOSTextField Scrollrecttop
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Scrollrecttop, 1, ScrollRectLeft, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Scrollrecttop, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   Scrollrecttop, 3, ScrollRectLeft, 3, False, +1.00, 2, 1, 0, 
-      AutoLayout      =   Scrollrecttop, 1, ScrollRectLeft, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Scrollrecttop, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -556,9 +551,9 @@ Begin iosView TableView
    Begin iOSButton Scrollbutton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Scrollbutton, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Scrollbutton, 7, , 0, False, +1.00, 1, 1, 105, 
       AutoLayout      =   Scrollbutton, 3, Switch3, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Scrollbutton, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Scrollbutton, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Scroll To Rect"
       Enabled         =   True
@@ -576,9 +571,9 @@ Begin iosView TableView
    Begin iOSTextField ScrollrectHeigth
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScrollrectHeigth, 1, ScrollRectWidth, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ScrollrectHeigth, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ScrollrectHeigth, 3, ScrollRectWidth, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ScrollrectHeigth, 1, ScrollRectWidth, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ScrollrectHeigth, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -600,9 +595,9 @@ Begin iosView TableView
    Begin iOSTextField ScrollRectWidth
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScrollRectWidth, 1, Scrollrecttop, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ScrollRectWidth, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ScrollRectWidth, 3, Scrollrecttop, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ScrollRectWidth, 1, Scrollrecttop, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ScrollRectWidth, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -624,10 +619,10 @@ Begin iosView TableView
    Begin iOSSwitch Switch4
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch4, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   Switch4, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   Switch4, 3, Scrollbutton, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Switch4, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch4, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
+      AutoLayout      =   Switch4, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch4, 3, Scrollbutton, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   31.0
       Left            =   20
@@ -641,9 +636,9 @@ Begin iosView TableView
    Begin iOSLabel Label12
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label12, 2, Button1, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label12, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label12, 3, Switch4, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label12, 2, Button1, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label12, 1, Switch4, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   30.0
@@ -662,9 +657,9 @@ Begin iosView TableView
    Begin iOSLabel Label13
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label13, 7, , 0, False, +1.00, 1, 1, 83, 
       AutoLayout      =   Label13, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label13, 3, Switch5, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label13, 7, , 0, False, +1.00, 1, 1, 83, 
       AutoLayout      =   Label13, 1, Switch5, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   30.0
@@ -683,10 +678,10 @@ Begin iosView TableView
    Begin iOSSwitch Switch5
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch5, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Switch5, 3, Label4, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Switch5, 1, Label1, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Switch5, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch5, 3, Label4, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Switch5, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch5, 1, Label1, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
       Left            =   197
@@ -700,9 +695,9 @@ Begin iosView TableView
    Begin iOSLabel Label14
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label14, 7, , 0, False, +1.00, 1, 1, 124, 
       AutoLayout      =   Label14, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label14, 3, Label12, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label14, 7, , 0, False, +1.00, 1, 1, 124, 
       AutoLayout      =   Label14, 1, <Parent>, 1, False, +1.00, 1, 1, 162, 
       Enabled         =   True
       Height          =   30.0
@@ -721,10 +716,10 @@ Begin iosView TableView
    Begin iOSSwitch alwysBH
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   alwysBH, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   alwysBH, 3, Label14, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   alwysBH, 1, Label14, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   alwysBH, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   alwysBH, 3, Label14, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   alwysBH, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   alwysBH, 1, Label14, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
       Left            =   294
@@ -738,9 +733,9 @@ Begin iosView TableView
    Begin iOSLabel Label15
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label15, 7, , 0, False, +1.00, 1, 1, 82, 
       AutoLayout      =   Label15, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label15, 3, alwysBH, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label15, 7, , 0, False, +1.00, 1, 1, 82, 
       AutoLayout      =   Label15, 1, alwysBH, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   30.0
@@ -759,10 +754,10 @@ Begin iosView TableView
    Begin iOSSwitch alwysBV
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   alwysBV, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   alwysBV, 1, Label15, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   alwysBV, 3, alwysBH, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   alwysBV, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   alwysBV, 1, Label15, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   alwysBV, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   alwysBV, 3, alwysBH, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
       Left            =   443
@@ -776,9 +771,9 @@ Begin iosView TableView
    Begin iOSButton Button6
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button6, 3, Scrollbutton1, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Button6, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button6, 1, Label16, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Button6, 3, Scrollbutton1, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Button6, 7, , 0, False, +1.00, 1, 1, 152, 
       Caption         =   "Flash Scrollbars"
       Enabled         =   True
@@ -796,9 +791,9 @@ Begin iosView TableView
    Begin iOSSegmentedControl IndicatorControl
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   IndicatorControl, 1, Switch4, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   IndicatorControl, 3, Switch4, 4, False, +1.00, 1, 1, 26, 
       AutoLayout      =   IndicatorControl, 2, Scrollrecttop, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
-      AutoLayout      =   IndicatorControl, 1, Switch4, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   IndicatorControl, 8, , 0, True, +1.00, 1, 1, 29, 
       Caption         =   ""
       Enabled         =   True
@@ -815,8 +810,8 @@ Begin iosView TableView
    Begin iOSLabel Label17
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Label17, 3, IndicatorControl, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label17, 1, IndicatorControl, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   Label17, 3, IndicatorControl, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label17, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -830,19 +825,19 @@ Begin iosView TableView
       TextSize        =   0
       Top             =   774
       Visible         =   True
-      Width           =   -232.0
+      Width           =   -438.0
    End
    Begin iOSTextField ContentSizeW
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentSizeW, 1, Label17, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentSizeW, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentSizeW, 3, Label17, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentSizeW, 1, Label17, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentSizeW, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
       KeyboardType    =   "0"
-      Left            =   8
+      Left            =   -198
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "X"
@@ -859,14 +854,14 @@ Begin iosView TableView
    Begin iOSTextField ContentSizeH
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentSizeH, 1, ContentSizeW, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentSizeH, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentSizeH, 3, ContentSizeW, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentSizeH, 1, ContentSizeW, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentSizeH, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
       KeyboardType    =   "0"
-      Left            =   107
+      Left            =   -99
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   "Y"
@@ -883,14 +878,14 @@ Begin iosView TableView
    Begin iOSButton Button7
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button7, 1, ContentSizeH, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button7, 7, , 0, False, +1.00, 1, 1, 64, 
       AutoLayout      =   Button7, 3, ContentSizeH, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Button7, 1, ContentSizeH, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button7, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set"
       Enabled         =   True
       Height          =   30.0
-      Left            =   206
+      Left            =   0
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -903,9 +898,9 @@ Begin iosView TableView
    Begin iOSLabel Label18
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label18, 2, Label14, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   Label18, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label18, 3, IndicatorControl, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Label18, 2, Label14, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   Label18, 1, IndicatorControl, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   30.0
@@ -924,9 +919,9 @@ Begin iosView TableView
    Begin iOSTextField DecRate
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DecRate, 2, alwysBH, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   DecRate, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   DecRate, 3, Label18, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   DecRate, 2, alwysBH, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   DecRate, 1, Label18, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
@@ -948,9 +943,9 @@ Begin iosView TableView
    Begin iOSButton Button8
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button8, 1, DecRate, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button8, 7, , 0, False, +1.00, 1, 1, 64, 
       AutoLayout      =   Button8, 3, DecRate, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Button8, 1, DecRate, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button8, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Set"
       Enabled         =   True
@@ -968,9 +963,9 @@ Begin iosView TableView
    Begin iOSButton Scrollbutton1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Scrollbutton1, 1, ScrollrectHeigth, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Scrollbutton1, 7, , 0, False, +1.00, 1, 1, 105, 
       AutoLayout      =   Scrollbutton1, 3, ScrollrectHeigth, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Scrollbutton1, 1, ScrollrectHeigth, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Scrollbutton1, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Zoom To Rect"
       Enabled         =   True
@@ -988,16 +983,16 @@ Begin iosView TableView
    Begin iOSSwitch Switch6
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch6, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Switch6, 3, Switch1, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Switch6, 1, Label4, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Switch6, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch6, 3, Switch1, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Switch6, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch6, 1, Label4, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   568.0
+      Left            =   568
       LockedInPosition=   False
       Scope           =   0
-      Top             =   523.0
+      Top             =   523
       Value           =   True
       Visible         =   True
       Width           =   51.0
@@ -1005,13 +1000,13 @@ Begin iosView TableView
    Begin iOSLabel Label20
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label20, 3, Switch6, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label20, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label20, 1, Switch6, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Label20, 3, Switch6, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label20, 7, , 0, False, +1.00, 1, 1, 117, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   627.0
+      Left            =   627
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Delays Touch"
@@ -1019,23 +1014,21 @@ Begin iosView TableView
       TextColor       =   &c00000000
       TextFont        =   ""
       TextSize        =   0
-      Top             =   523.0
+      Top             =   523
       Visible         =   True
       Width           =   117.0
    End
    Begin iOSLabel Label16
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label16, 3, alwysBV, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label16, 1, alwysBV, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label16, 2, Switch6, 1, False, +1.00, 2, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label16, 3, alwysBV, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label16, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
       Left            =   502
       LockedInPosition=   False
-      PanelIndex      =   -1
-      Parent          =   "nil"
       Scope           =   0
       Text            =   "Vertical"
       TextAlignment   =   "0"
@@ -1049,33 +1042,33 @@ Begin iosView TableView
    Begin iOSButton Button9
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button9, 3, RowHeightText, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button9, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button9, 1, RowHeightText, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Button9, 3, RowHeightText, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button9, 7, , 0, False, +1.00, 1, 1, 64, 
       Caption         =   "Set"
       Enabled         =   True
       Height          =   30.0
-      Left            =   529.0
+      Left            =   529
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
       TextFont        =   ""
       TextSize        =   0
-      Top             =   811.0
+      Top             =   811
       Visible         =   True
       Width           =   64.0
    End
    Begin iOSLabel Label21
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label21, 3, Button8, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label21, 1, Button8, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label21, 7, , 0, False, +1.00, 1, 1, 87, 
-      AutoLayout      =   Label21, 3, Button8, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label21, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   366.0
+      Left            =   366
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Row Height:"
@@ -1083,21 +1076,21 @@ Begin iosView TableView
       TextColor       =   &c00000000
       TextFont        =   ""
       TextSize        =   0
-      Top             =   811.0
+      Top             =   811
       Visible         =   True
       Width           =   87.0
    End
    Begin iOSTextField RowHeightText
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   RowHeightText, 3, Label21, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   RowHeightText, 1, Label21, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   RowHeightText, 2, Scrollbutton1, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
-      AutoLayout      =   RowHeightText, 3, Label21, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   RowHeightText, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
       KeyboardType    =   "0"
-      Left            =   461.0
+      Left            =   461
       LockedInPosition=   False
       Password        =   False
       PlaceHolder     =   ""
@@ -1107,9 +1100,93 @@ Begin iosView TableView
       TextColor       =   &c00000000
       TextFont        =   ""
       TextSize        =   0
-      Top             =   811.0
+      Top             =   811
       Visible         =   True
       Width           =   60.0
+   End
+   Begin iOSSegmentedControl SeparatorControl
+      AccessibilityHint=   ""
+      AccessibilityLabel=   ""
+      AutoLayout      =   SeparatorControl, 7, , 0, False, +1.00, 1, 1, 367, 
+      AutoLayout      =   SeparatorControl, 8, , 0, True, +1.00, 1, 1, 29, 
+      AutoLayout      =   SeparatorControl, 3, Label18, 4, False, +1.00, 1, 1, *kStdControlGapV, 
+      AutoLayout      =   SeparatorControl, 1, Label18, 1, False, +1.00, 1, 1, 0, 
+      Caption         =   ""
+      Enabled         =   True
+      Height          =   29.0
+      Left            =   20
+      LockedInPosition=   False
+      Scope           =   0
+      Segments        =   "None\n\nFalse\rSingleLine\n\nTrue\rEtched SingleLine\n\nFalse"
+      Top             =   849
+      Value           =   1
+      Visible         =   True
+      Width           =   367.0
+   End
+   Begin iOSLabel Label23
+      AccessibilityHint=   ""
+      AccessibilityLabel=   ""
+      AutoLayout      =   Label23, 3, SeparatorControl, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Label23, 1, SeparatorControl, 2, False, +1.00, 2, 1, *kStdControlGapH, 
+      AutoLayout      =   Label23, 2, Label6, 1, False, +1.00, 1, 1, 1, 
+      AutoLayout      =   Label23, 8, , 0, False, +1.00, 1, 1, 21, 
+      Enabled         =   True
+      Height          =   21.0
+      Left            =   395
+      LockedInPosition=   False
+      Scope           =   0
+      Text            =   "Separator BackGColor:"
+      TextAlignment   =   "0"
+      TextColor       =   &c00000000
+      TextFont        =   ""
+      TextSize        =   0
+      Top             =   849
+      Visible         =   True
+      Width           =   -67.0
+   End
+   Begin iostextfield BGColorField
+      AccessibilityHint=   ""
+      AccessibilityLabel=   ""
+      AutoLayout      =   BGColorField, 3, Label23, 3, False, +1.00, 2, 1, 0, 
+      AutoLayout      =   BGColorField, 1, Label23, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   BGColorField, 2, Button3, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
+      AutoLayout      =   BGColorField, 8, , 0, True, +1.00, 1, 1, 36, 
+      Enabled         =   True
+      Height          =   36.0
+      KeyboardType    =   "0"
+      Left            =   336
+      LockedInPosition=   False
+      Password        =   False
+      PlaceHolder     =   ""
+      Scope           =   0
+      Text            =   ""
+      TextAlignment   =   "1"
+      TextColor       =   &c00000000
+      TextFont        =   ""
+      TextSize        =   0
+      Top             =   849
+      Visible         =   True
+      Width           =   337.0
+   End
+   Begin iOSButton Button10
+      AccessibilityHint=   ""
+      AccessibilityLabel=   ""
+      AutoLayout      =   Button10, 1, BGColorField, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   Button10, 7, , 0, False, +1.00, 1, 1, 64, 
+      AutoLayout      =   Button10, 3, BGColorField, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Button10, 8, , 0, False, +1.00, 1, 1, 30, 
+      Caption         =   "Set"
+      Enabled         =   True
+      Height          =   30.0
+      Left            =   681
+      LockedInPosition=   False
+      Scope           =   0
+      TextColor       =   &c007AFF00
+      TextFont        =   ""
+      TextSize        =   0
+      Top             =   849
+      Visible         =   True
+      Width           =   64.0
    End
 End
 #tag EndIOSView
@@ -1127,20 +1204,22 @@ End
 		Private Sub UpdateValues()
 		  ContentOffsetX.text = TextArea1.ContentOffset.x.ToText(locale.Current, "#.###")
 		  ContentOffsetY.text = TextArea1.ContentOffset.y.ToText(locale.Current, "#.###")
-		  // 
+		  //
 		  dim myoffset as UIEdgeInsets64Bit = TextArea1.ContentInset
 		  ContentinsetTop.text = myoffset.Top.totext(locale.Current, "#.###")
 		  ContentInsetBottom.text = myoffset.Bottom.totext(locale.Current, "#.###")
 		  ContentInsetLeft.text = myoffset.Left.totext(locale.Current, "#.###")
 		  ContentInsetRight.text = myoffset.Right.totext(locale.Current, "#.###")
-		  // 
+		  //
 		  dim cSize as size = TextArea1.ContentSize
 		  ContentSizeW.text = cSize.Width.totext(locale.Current, "###.##")
 		  ContentSizeH.text = cSize.Height.totext(locale.Current, "###.##")
-		  // 
+		  //
 		  DecRate.text = TextArea1.DecelerationRate.ToText
 		  
 		  RowHeightText.text = TextArea1.RowHeight.ToText
+		  
+		  BGColorField.text = TextArea1.SeparatorColor.totext
 		  
 		End Sub
 	#tag EndMethod
@@ -1159,14 +1238,24 @@ End
 #tag Events TextArea1
 	#tag Event
 		Sub Open()
+		  me.viewhandle = NIL
 		  me.BackgroundColor = &c435B9600
 		  me.RowHeight = 65
+		  me.SectionHeaderHeight = 80
 		  me.AddSection ("First Section")
 		  for q as integer = 1 to 100
 		    me.AddRow (0, new iOSTableCellData (q.ToText+". Line"))
 		  next
 		  me.MaximumZoomScale = 500
 		  me.MinimumZoomScale = 0.01
+		  dim mds as ptr = me.DataSourcePtr
+		  
+		  // The following only to find why cell coloring is unrealiable.
+		  me.CellBackgroundColor(0,0) = &cCC092000
+		  me.CellBackgroundColor(1,0) = &c07710088
+		  me.CellsBackgroundColor = &cDED62D00
+		  me.ReloadData
+		  dim mydelegate as ptr = iOSControlExtension.getDelegate (me.Handle)
 		  UpdateValues
 		  
 		End Sub
@@ -1195,7 +1284,7 @@ End
 	#tag Event
 		Sub Action()
 		  dim mypoint as new point (double.FromText(ContentOffsetX.Text), double.FromText (ContentOffsetY.text))
-		  if animatedSwitch.value then 
+		  if animatedSwitch.value then
 		    TextArea1.ContentOffsetAnimated =  mypoint
 		  else
 		    TextArea1.ContentOffset =  mypoint
@@ -1387,6 +1476,28 @@ End
 	#tag Event
 		Sub Action()
 		  TextArea1.rowheight = double.FromText (RowHeightText.text)
+		  TextArea1.ReloadData
+		End Sub
+	#tag EndEvent
+#tag EndEvents
+#tag Events SeparatorControl
+	#tag Event
+		Sub ValueChanged()
+		  select case me.value
+		  case 0
+		    TextArea1.SeparatorStyle = iOSTableExtension.SeparatorStyles.None
+		  case 1
+		    TextArea1.SeparatorStyle = iOSTableExtension.SeparatorStyles.SingleLine
+		  case 2
+		    TextArea1.SeparatorStyle = iOSTableExtension.SeparatorStyles.SingleLineEtched
+		  end select
+		End Sub
+	#tag EndEvent
+#tag EndEvents
+#tag Events Button10
+	#tag Event
+		Sub Action()
+		  TextArea1.SeparatorColor =BGColorField.text.ColorFromHex
 		End Sub
 	#tag EndEvent
 #tag EndEvents

--- a/Views/TextAreaView.xojo_code
+++ b/Views/TextAreaView.xojo_code
@@ -10,9 +10,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label3, 3, <Parent>, 3, False, +1.00, 1, 1, 91, 
       AutoLayout      =   Label3, 1, <Parent>, 1, False, +1.00, 1, 1, *kStdGapCtlToViewH, 
       AutoLayout      =   Label3, 2, <Parent>, 2, False, +1.00, 1, 1, -*kStdGapCtlToViewH, 
-      AutoLayout      =   Label3, 3, <Parent>, 3, False, +1.00, 1, 1, 91, 
       AutoLayout      =   Label3, 8, , 0, False, +1.00, 1, 1, 36, 
       Enabled         =   True
       Height          =   36.0
@@ -26,14 +26,14 @@ Begin iosView TextAreaView
       TextSize        =   0
       Top             =   91
       Visible         =   True
-      Width           =   728.0
+      Width           =   280.0
    End
    Begin iOSButton Button1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button1, 1, <Parent>, 1, False, +1.00, 2, 1, 20, 
       AutoLayout      =   Button1, 4, BottomLayoutGuide, 3, False, +1.00, 2, 1, -*kStdControlGapV, 
       AutoLayout      =   Button1, 8, , 0, False, +1.00, 1, 1, 30, 
-      AutoLayout      =   Button1, 1, <Parent>, 1, False, +1.00, 2, 1, 20, 
       AutoLayout      =   Button1, 7, , 0, False, +1.00, 1, 1, 141, 
       Caption         =   "Return to menu"
       Enabled         =   True
@@ -51,9 +51,9 @@ Begin iosView TextAreaView
    Begin iOSTextArea TextArea1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   TextArea1, 2, Label3, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TextArea1, 8, , 0, False, +1.00, 1, 1, 336, 
       AutoLayout      =   TextArea1, 3, <Parent>, 3, False, +1.00, 1, 1, 147, 
-      AutoLayout      =   TextArea1, 2, Label3, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   TextArea1, 1, Label3, 1, False, +1.00, 1, 1, 0, 
       Editable        =   True
       Height          =   336.0
@@ -68,15 +68,15 @@ Begin iosView TextAreaView
       TextSize        =   0
       Top             =   147
       Visible         =   True
-      Width           =   728.0
+      Width           =   280.0
    End
    Begin iOSSwitch Switch1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch1, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Switch1, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
-      AutoLayout      =   Switch1, 1, TextArea1, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Switch1, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch1, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
+      AutoLayout      =   Switch1, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch1, 1, TextArea1, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
       Left            =   20
@@ -90,9 +90,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label1, 7, , 0, False, +1.00, 1, 1, 264, 
       AutoLayout      =   Label1, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label1, 3, Switch1, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label1, 7, , 0, False, +1.00, 1, 1, 264, 
       AutoLayout      =   Label1, 1, Switch1, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   30.0
@@ -111,13 +111,13 @@ Begin iosView TextAreaView
    Begin iOSLabel Label4
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label4, 2, Label9, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   Label4, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label4, 3, Switch2, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label4, 2, Label9, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   Label4, 1, Switch2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   443
+      Left            =   219
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Bounces Zoom"
@@ -127,18 +127,18 @@ Begin iosView TextAreaView
       TextSize        =   0
       Top             =   523
       Visible         =   True
-      Width           =   117.0
+      Width           =   341.0
    End
    Begin iOSSwitch Switch2
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch2, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   Switch2, 1, TextArea1, 9, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Switch2, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
       AutoLayout      =   Switch2, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch2, 1, TextArea1, 9, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Switch2, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch2, 3, TextArea1, 4, False, +1.00, 1, 1, 40, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   384
+      Left            =   160
       LockedInPosition=   False
       Scope           =   0
       Top             =   523
@@ -149,9 +149,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentOffsetX
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentOffsetX, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentOffsetX, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentOffsetX, 3, Label5, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentOffsetX, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentOffsetX, 1, Label5, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
@@ -173,9 +173,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label5
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label5, 7, , 0, False, +1.00, 1, 1, 148, 
       AutoLayout      =   Label5, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label5, 3, Switch1, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Label5, 7, , 0, False, +1.00, 1, 1, 148, 
       AutoLayout      =   Label5, 1, Switch1, 1, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   30.0
@@ -194,9 +194,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentOffsetY
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentOffsetY, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentOffsetY, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentOffsetY, 3, Label5, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentOffsetY, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentOffsetY, 1, ContentOffsetX, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
@@ -218,14 +218,14 @@ Begin iosView TextAreaView
    Begin iOSButton Button2
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button2, 3, ContentOffsetY, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button2, 1, Switch2, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button2, 7, , 0, False, +1.00, 1, 1, 100, 
-      AutoLayout      =   Button2, 3, ContentOffsetY, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button2, 4, Label5, 4, False, +1.00, 1, 1, 0, 
       Caption         =   "Set"
       Enabled         =   True
       Height          =   30.0
-      Left            =   384
+      Left            =   160
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -238,13 +238,13 @@ Begin iosView TextAreaView
    Begin iOSSwitch animatedSwitch
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   animatedSwitch, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   animatedSwitch, 1, Button2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   animatedSwitch, 3, ContentOffsetX, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   animatedSwitch, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   animatedSwitch, 1, Button2, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   animatedSwitch, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   animatedSwitch, 3, ContentOffsetX, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
-      Left            =   492
+      Left            =   268
       LockedInPosition=   False
       Scope           =   0
       Top             =   562
@@ -255,13 +255,13 @@ Begin iosView TextAreaView
    Begin iOSLabel Label6
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label6, 2, TextArea1, 2, False, +1.00, 1, 1, -103, 
       AutoLayout      =   Label6, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label6, 1, animatedSwitch, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Label6, 2, TextArea1, 2, False, +1.00, 1, 1, -103, 
       AutoLayout      =   Label6, 3, Switch1, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       Enabled         =   True
       Height          =   30.0
-      Left            =   551
+      Left            =   327
       LockedInPosition=   False
       Scope           =   0
       Text            =   "Animated"
@@ -271,14 +271,14 @@ Begin iosView TextAreaView
       TextSize        =   0
       Top             =   562
       Visible         =   True
-      Width           =   94.0
+      Width           =   -130.0
    End
    Begin iOSLabel Label7
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label7, 3, animatedSwitch, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label7, 1, Switch1, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label7, 2, ContentOffsetY, 1, False, +1.00, 2, 1, 2, 
-      AutoLayout      =   Label7, 3, animatedSwitch, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label7, 4, ContentinsetTop, 4, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
@@ -297,9 +297,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentinsetTop
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentinsetTop, 3, Label7, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentinsetTop, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentinsetTop, 1, Label7, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ContentinsetTop, 3, Label7, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentinsetTop, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -321,9 +321,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentInsetLeft
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentInsetLeft, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentInsetLeft, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentInsetLeft, 3, ContentinsetTop, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentInsetLeft, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentInsetLeft, 1, ContentinsetTop, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
@@ -345,9 +345,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentInsetBottom
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentInsetBottom, 1, ContentInsetLeft, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentInsetBottom, 7, , 0, False, +1.00, 1, 1, 91, 
       AutoLayout      =   ContentInsetBottom, 3, ContentinsetTop, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   ContentInsetBottom, 1, ContentInsetLeft, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   ContentInsetBottom, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -369,9 +369,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentInsetRight
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentInsetRight, 3, ContentInsetBottom, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentInsetRight, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentInsetRight, 1, ContentInsetBottom, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ContentInsetRight, 3, ContentInsetBottom, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentInsetRight, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -393,9 +393,9 @@ Begin iosView TextAreaView
    Begin iOSButton Button3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button3, 7, , 0, False, +1.00, 1, 1, 64, 
       AutoLayout      =   Button3, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button3, 3, ContentInsetRight, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Button3, 7, , 0, False, +1.00, 1, 1, 64, 
       AutoLayout      =   Button3, 1, ContentInsetRight, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Caption         =   "Set"
       Enabled         =   True
@@ -413,14 +413,14 @@ Begin iosView TextAreaView
    Begin iOSButton Button5
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button5, 1, Label6, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button5, 7, , 0, False, +1.00, 1, 1, 64, 
       AutoLayout      =   Button5, 3, Label6, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Button5, 1, Label6, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button5, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Refresh"
       Enabled         =   True
       Height          =   30.0
-      Left            =   653
+      Left            =   205
       LockedInPosition=   False
       Scope           =   0
       TextColor       =   &c007AFF00
@@ -433,10 +433,10 @@ Begin iosView TextAreaView
    Begin iOSSwitch Switch3
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch3, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Switch3, 3, Label7, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Switch3, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Switch3, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch3, 3, Label7, 4, False, +1.00, 1, 1, *kStdControlGapV, 
+      AutoLayout      =   Switch3, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch3, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       Enabled         =   True
       Height          =   31.0
       Left            =   20
@@ -450,9 +450,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label8
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label8, 3, Switch3, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label8, 1, Switch3, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label8, 7, , 0, False, +1.00, 1, 1, 422, 
-      AutoLayout      =   Label8, 3, Switch3, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label8, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -471,10 +471,10 @@ Begin iosView TextAreaView
    Begin iOSSwitch DirectionalSwitch
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   DirectionalSwitch, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   DirectionalSwitch, 3, Label8, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   DirectionalSwitch, 1, Label8, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   DirectionalSwitch, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   DirectionalSwitch, 3, Label8, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   DirectionalSwitch, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   DirectionalSwitch, 1, Label8, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
       Left            =   509
@@ -488,8 +488,8 @@ Begin iosView TextAreaView
    Begin iOSLabel Label9
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Label9, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label9, 1, DirectionalSwitch, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   Label9, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label9, 3, DirectionalSwitch, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   30.0
@@ -508,9 +508,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ScrollRectLeft
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScrollRectLeft, 3, Scrollbutton, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   ScrollRectLeft, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ScrollRectLeft, 1, Scrollbutton, 2, False, +1.00, 2, 1, *kStdControlGapH, 
-      AutoLayout      =   ScrollRectLeft, 3, Scrollbutton, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   ScrollRectLeft, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -532,9 +532,9 @@ Begin iosView TextAreaView
    Begin iOSTextField Scrollrecttop
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Scrollrecttop, 3, ScrollRectLeft, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   Scrollrecttop, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   Scrollrecttop, 1, ScrollRectLeft, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Scrollrecttop, 3, ScrollRectLeft, 3, False, +1.00, 2, 1, 0, 
       AutoLayout      =   Scrollrecttop, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -556,9 +556,9 @@ Begin iosView TextAreaView
    Begin iOSButton Scrollbutton
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Scrollbutton, 3, Switch3, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Scrollbutton, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Scrollbutton, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   Scrollbutton, 3, Switch3, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Scrollbutton, 7, , 0, False, +1.00, 1, 1, 105, 
       Caption         =   "Scroll To Rect"
       Enabled         =   True
@@ -576,9 +576,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ScrollrectHeigth
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScrollrectHeigth, 3, ScrollRectWidth, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ScrollrectHeigth, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ScrollrectHeigth, 1, ScrollRectWidth, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ScrollrectHeigth, 3, ScrollRectWidth, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ScrollrectHeigth, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -600,9 +600,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ScrollRectWidth
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ScrollRectWidth, 3, Scrollrecttop, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ScrollRectWidth, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ScrollRectWidth, 1, Scrollrecttop, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ScrollRectWidth, 3, Scrollrecttop, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ScrollRectWidth, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -624,10 +624,10 @@ Begin iosView TextAreaView
    Begin iOSSwitch Switch4
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch4, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Switch4, 3, Scrollbutton, 4, False, +1.00, 1, 1, *kStdControlGapV, 
-      AutoLayout      =   Switch4, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       AutoLayout      =   Switch4, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch4, 3, Scrollbutton, 4, False, +1.00, 1, 1, *kStdControlGapV, 
+      AutoLayout      =   Switch4, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch4, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
       Enabled         =   True
       Height          =   31.0
       Left            =   20
@@ -641,9 +641,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label12
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label12, 3, Switch4, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label12, 1, Switch4, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label12, 2, Button1, 2, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Label12, 3, Switch4, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label12, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -662,9 +662,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label13
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label13, 3, Switch5, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label13, 1, Switch5, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label13, 7, , 0, False, +1.00, 1, 1, 83, 
-      AutoLayout      =   Label13, 3, Switch5, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label13, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -683,10 +683,10 @@ Begin iosView TextAreaView
    Begin iOSSwitch Switch5
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Switch5, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   Switch5, 3, Label4, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   Switch5, 1, Label4, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Switch5, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   Switch5, 3, Label4, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   Switch5, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   Switch5, 1, Label4, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
       Left            =   568
@@ -700,9 +700,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label14
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label14, 3, Label12, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label14, 1, <Parent>, 1, False, +1.00, 1, 1, 162, 
       AutoLayout      =   Label14, 7, , 0, False, +1.00, 1, 1, 124, 
-      AutoLayout      =   Label14, 3, Label12, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label14, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -721,10 +721,10 @@ Begin iosView TextAreaView
    Begin iOSSwitch alwysBH
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   alwysBH, 8, , 0, True, +1.00, 1, 1, 31, 
-      AutoLayout      =   alwysBH, 1, Label14, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   alwysBH, 3, Label14, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   alwysBH, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   alwysBH, 1, Label14, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   alwysBH, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   alwysBH, 3, Label14, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   31.0
       Left            =   294
@@ -738,9 +738,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label15
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label15, 3, alwysBH, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label15, 1, alwysBH, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label15, 7, , 0, False, +1.00, 1, 1, 82, 
-      AutoLayout      =   Label15, 3, alwysBH, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label15, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -759,9 +759,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label16
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label16, 3, alwysBV, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label16, 1, alwysBV, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Label16, 2, Switch5, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label16, 3, alwysBV, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label16, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -780,10 +780,10 @@ Begin iosView TextAreaView
    Begin iOSSwitch alwysBV
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   alwysBV, 7, , 0, True, +1.00, 1, 1, 51, 
-      AutoLayout      =   alwysBV, 3, alwysBH, 3, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   alwysBV, 1, Label15, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   alwysBV, 8, , 0, True, +1.00, 1, 1, 31, 
+      AutoLayout      =   alwysBV, 3, alwysBH, 3, False, +1.00, 1, 1, 0, 
+      AutoLayout      =   alwysBV, 7, , 0, True, +1.00, 1, 1, 51, 
+      AutoLayout      =   alwysBV, 1, Label15, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       Enabled         =   True
       Height          =   31.0
       Left            =   443
@@ -797,9 +797,9 @@ Begin iosView TextAreaView
    Begin iOSButton Button6
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button6, 3, ScrollRectWidth, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Button6, 1, Label16, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   Button6, 7, , 0, False, +1.00, 1, 1, 152, 
-      AutoLayout      =   Button6, 3, ScrollRectWidth, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Button6, 8, , 0, False, +1.00, 1, 1, 30, 
       Caption         =   "Flash Scrollbars"
       Enabled         =   True
@@ -817,9 +817,9 @@ Begin iosView TextAreaView
    Begin iOSSegmentedControl IndicatorControl
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   IndicatorControl, 2, Scrollrecttop, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   IndicatorControl, 8, , 0, True, +1.00, 1, 1, 29, 
       AutoLayout      =   IndicatorControl, 1, Switch4, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   IndicatorControl, 2, Scrollrecttop, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
       AutoLayout      =   IndicatorControl, 3, Switch4, 4, False, +1.00, 1, 1, 26, 
       Caption         =   ""
       Enabled         =   True
@@ -836,8 +836,8 @@ Begin iosView TextAreaView
    Begin iOSLabel Label17
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
-      AutoLayout      =   Label17, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label17, 1, IndicatorControl, 2, False, +1.00, 1, 1, *kStdControlGapH, 
+      AutoLayout      =   Label17, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Label17, 3, IndicatorControl, 3, False, +1.00, 1, 1, 0, 
       Enabled         =   True
       Height          =   30.0
@@ -856,9 +856,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentSizeW
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentSizeW, 3, Label17, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentSizeW, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentSizeW, 1, Label17, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ContentSizeW, 3, Label17, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentSizeW, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -880,9 +880,9 @@ Begin iosView TextAreaView
    Begin iOSTextField ContentSizeH
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   ContentSizeH, 3, ContentSizeW, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentSizeH, 8, , 0, True, +1.00, 1, 1, 31, 
       AutoLayout      =   ContentSizeH, 1, ContentSizeW, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   ContentSizeH, 3, ContentSizeW, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   ContentSizeH, 7, , 0, False, +1.00, 1, 1, 91, 
       Enabled         =   True
       Height          =   31.0
@@ -904,9 +904,9 @@ Begin iosView TextAreaView
    Begin iOSButton Button7
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button7, 3, ContentSizeH, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button7, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button7, 1, ContentSizeH, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Button7, 3, ContentSizeH, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button7, 7, , 0, False, +1.00, 1, 1, 64, 
       Caption         =   "Set"
       Enabled         =   True
@@ -924,9 +924,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label18
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label18, 3, IndicatorControl, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label18, 1, IndicatorControl, 1, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label18, 2, Label14, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
-      AutoLayout      =   Label18, 3, IndicatorControl, 4, False, +1.00, 1, 1, *kStdControlGapV, 
       AutoLayout      =   Label18, 8, , 0, False, +1.00, 1, 1, 30, 
       Enabled         =   True
       Height          =   30.0
@@ -945,9 +945,9 @@ Begin iosView TextAreaView
    Begin iOSTextField DecRate
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DecRate, 3, Label18, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DecRate, 1, Label18, 2, False, +1.00, 1, 1, *kStdControlGapH, 
       AutoLayout      =   DecRate, 2, alwysBH, 1, False, +1.00, 1, 1, -*kStdControlGapH, 
-      AutoLayout      =   DecRate, 3, Label18, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   DecRate, 8, , 0, True, +1.00, 1, 1, 31, 
       Enabled         =   True
       Height          =   31.0
@@ -969,9 +969,9 @@ Begin iosView TextAreaView
    Begin iOSButton Button8
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Button8, 3, DecRate, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button8, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Button8, 1, DecRate, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Button8, 3, DecRate, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Button8, 7, , 0, False, +1.00, 1, 1, 64, 
       Caption         =   "Set"
       Enabled         =   True
@@ -989,9 +989,9 @@ Begin iosView TextAreaView
    Begin iOSButton Scrollbutton1
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Scrollbutton1, 3, ScrollrectHeigth, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Scrollbutton1, 8, , 0, False, +1.00, 1, 1, 30, 
       AutoLayout      =   Scrollbutton1, 1, ScrollrectHeigth, 2, False, +1.00, 1, 1, *kStdControlGapH, 
-      AutoLayout      =   Scrollbutton1, 3, ScrollrectHeigth, 3, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Scrollbutton1, 7, , 0, False, +1.00, 1, 1, 105, 
       Caption         =   "Zoom To Rect"
       Enabled         =   True
@@ -1009,9 +1009,9 @@ Begin iosView TextAreaView
    Begin iOSSegmentedControl DDetectorControl
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   DDetectorControl, 3, Button8, 4, False, +1.00, 1, 1, 24, 
       AutoLayout      =   DDetectorControl, 8, , 0, True, +1.00, 1, 1, 29, 
       AutoLayout      =   DDetectorControl, 1, Label18, 1, False, +1.00, 1, 1, 0, 
-      AutoLayout      =   DDetectorControl, 3, Button8, 4, False, +1.00, 1, 1, 24, 
       AutoLayout      =   DDetectorControl, 7, , 0, False, +1.00, 1, 1, 579, 
       Caption         =   ""
       Enabled         =   True
@@ -1028,9 +1028,9 @@ Begin iosView TextAreaView
    Begin iOSLabel Label19
       AccessibilityHint=   ""
       AccessibilityLabel=   ""
+      AutoLayout      =   Label19, 2, Button3, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label19, 8, , 0, False, +1.00, 1, 1, 42, 
       AutoLayout      =   Label19, 1, <Parent>, 1, False, +1.00, 1, 1, 20, 
-      AutoLayout      =   Label19, 2, Button3, 2, False, +1.00, 1, 1, 0, 
       AutoLayout      =   Label19, 3, DDetectorControl, 4, False, +1.00, 1, 1, 20, 
       Enabled         =   True
       Height          =   42.0
@@ -1123,7 +1123,7 @@ End
 	#tag Event
 		Sub Action()
 		  dim mypoint as new point (double.FromText(ContentOffsetX.Text), double.FromText (ContentOffsetY.text))
-		  if animatedSwitch.value then 
+		  if animatedSwitch.value then
 		    TextArea1.ContentOffsetAnimated =  mypoint
 		  else
 		    TextArea1.ContentOffset =  mypoint

--- a/iOSControls/Class Extensions/CoreRectExtension.xojo_code
+++ b/iOSControls/Class Extensions/CoreRectExtension.xojo_code
@@ -1,6 +1,12 @@
 #tag Module
 Protected Module CoreRectExtension
 	#tag Method, Flags = &h0
+		Function fromCGRect(aRect as CGRect) As Rect
+		  return new rect (CorePointExtension.fromGCPoint (aRect.origin), CoreSizeExtension.fromCGSize (aRect.rectSize))
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
 		Function toCGRect(extends arect as xojo.core.rect) As CGRect
 		  dim myrect as CGRect
 		  myrect.origin = aRect.Origin.toCGPoint

--- a/iOSControls/Class Extensions/iOSApplicationExtension.xojo_code
+++ b/iOSControls/Class Extensions/iOSApplicationExtension.xojo_code
@@ -14,7 +14,7 @@ Protected Module iOSApplicationExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub HideStatusBarAnimated(extends a as iOSApplication,  value as StatusBarAnimation)
+		Sub HideStatusBarAnimated(extends a as iOSApplication, value as StatusBarAnimation)
 		  setStatusbarhiddenwithAnimation a.Handle, true, value
 		End Sub
 	#tag EndMethod
@@ -34,7 +34,7 @@ Protected Module iOSApplicationExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub ShowStatusBarAnimated(extends a as iOSApplication,  value as StatusBarAnimation)
+		Sub ShowStatusBarAnimated(extends a as iOSApplication, value as StatusBarAnimation)
 		  setStatusbarhiddenwithAnimation a.Handle, false, value
 		End Sub
 	#tag EndMethod

--- a/iOSControls/Class Extensions/iOSControlExtension.xojo_code
+++ b/iOSControls/Class Extensions/iOSControlExtension.xojo_code
@@ -11,7 +11,7 @@ Protected Module iOSControlExtension
 		  // case UIGestureRecognizer.GestureRecognizerTypes.Tap
 		  //  newRecognizer = new UITapGestureRecognizer (c.Handle)
 		  // // newRecognizer = new UITapGestureRecognizer (c.Handle,  UIGestureRecognizer.GestureRecognizerTypes.Tap, UIGestureRecognizer.classptr)
-		  // 
+		  //
 		  // end select
 		  // AddGestureRecognizer (c.Handle, newRecognizer.Handle)
 		  // end if
@@ -43,7 +43,7 @@ Protected Module iOSControlExtension
 	#tag Method, Flags = &h0
 		Function alloc(aClass as Ptr) As Ptr
 		  declare function alloc lib UIKit selector "alloc" (id as ptr) as ptr
-		  return alloc (aclass) 
+		  return alloc (aclass)
 		End Function
 	#tag EndMethod
 
@@ -162,7 +162,7 @@ Protected Module iOSControlExtension
 
 	#tag Method, Flags = &h0
 		Sub BackgroundColor(extends c as iOSControl, assigns value as color)
-		  setBackgroundColor c.Handle, value.uicolor
+		  setBackgroundColor c.Handle, value.touicolor
 		End Sub
 	#tag EndMethod
 
@@ -495,6 +495,13 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
+		Protected Function getDelegate(id as ptr) As ptr
+		  declare function delegate_ lib uikit selector "delegate" (id as ptr) as ptr
+		  return Delegate_ (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
 		Protected Function getExclusiveTouch(id as ptr) As Boolean
 		  declare Function isExclusiveTouch lib UIKit selector "isExclusiveTouch" (id as ptr) as Boolean
 		  return isExclusiveTouch (id)
@@ -511,7 +518,7 @@ Protected Module iOSControlExtension
 	#tag Method, Flags = &h1
 		Protected Function getGestureRecognizers(id as ptr) As Ptr
 		  declare function gestureRecognizers lib UIKit selector "gestureRecognizers"(id as ptr) as ptr
-		  return gestureRecognizers (id) 
+		  return gestureRecognizers (id)
 		End Function
 	#tag EndMethod
 
@@ -697,7 +704,7 @@ Protected Module iOSControlExtension
 
 	#tag Method, Flags = &h1
 		Protected Function init(obj_id as ptr) As ptr
-		  declare function init lib UIKit selector "init" (obj_id as ptr) as ptr  
+		  declare function init lib UIKit selector "init" (obj_id as ptr) as ptr
 		  Return init(obj_id)
 		End Function
 	#tag EndMethod
@@ -903,7 +910,7 @@ Protected Module iOSControlExtension
 
 	#tag Method, Flags = &h0
 		Sub performSelector(extends c as ioscontrol, aSelector as cfstringref, delay as double, anObject as Ptr = NIL)
-		  Declare Sub performSelectorwithObjectafterDelay lib UIKit selector "performSelector:withObject:afterDelay:"(id as ptr, aselector as Ptr, withObject as Ptr, delay as double) 
+		  Declare Sub performSelectorwithObjectafterDelay lib UIKit selector "performSelector:withObject:afterDelay:"(id as ptr, aselector as Ptr, withObject as Ptr, delay as double)
 		  
 		  performSelectorwithObjectafterDelay (c.handle, NSSelectorFromString (aSelector), anObject, delay)
 		  
@@ -1040,7 +1047,7 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub RotateAnimated(extends c as ioscontrol, angle as Single, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef ="")
+		Sub RotateAnimated(extends c as ioscontrol, angle as Single, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef = "")
 		  c.setOldAnimationProperties (Seconds, delay, curve, transition, cacheTransition, repeat, autoreverse, continueFromCurrentState, fromCurrentTransform, startdate, animationname)
 		  c.Transform = if (fromCurrentTransform, CGAffineTransformRotate (c.Transform, angle.DegreesToRadians), CGAffineTransformMakeRotation (angle.DegreesToRadians))
 		  commitAnimations
@@ -1050,10 +1057,10 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Scale(extends c as ioscontrol, Xscale as double, yScale as Double= 0, fromCurrent as Boolean = false)
+		Sub Scale(extends c as ioscontrol, Xscale as double, yScale as Double = 0, fromCurrent as Boolean = false)
 		  Xscale = Xscale / 100
 		  if yScale = 0 then
-		     yScale = Xscale // proprtional if only one value
+		    yScale = Xscale // proprtional if only one value
 		  else
 		    yScale = yScale / 100
 		  end if
@@ -1062,7 +1069,7 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub ScaleAnimated(extends c as ioscontrol, Xscale as double, yScale as Double= 0,  Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef ="")
+		Sub ScaleAnimated(extends c as ioscontrol, Xscale as double, yScale as Double = 0, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef = "")
 		  Xscale = Xscale / 100
 		  if yScale = 0 then
 		    yScale = Xscale // proprtional if only one value
@@ -1113,7 +1120,7 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub setAlphaAnimated(extends c as ioscontrol, NewAlpha as Double, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef ="")
+		Sub setAlphaAnimated(extends c as ioscontrol, NewAlpha as Double, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef = "")
 		  c.setOldAnimationProperties (Seconds, delay, curve, transition, cacheTransition, repeat, autoreverse, continueFromCurrentState, fromCurrentTransform, startdate, animationname)
 		  c.alpha = NewAlpha
 		  commitAnimations
@@ -1215,7 +1222,7 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub setBackgroundColorAnimated(extends c as ioscontrol, NewColor as Color, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef ="")
+		Sub setBackgroundColorAnimated(extends c as ioscontrol, NewColor as Color, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef = "")
 		  c.setOldAnimationProperties (Seconds, delay, curve, transition, cacheTransition, repeat, autoreverse, continueFromCurrentState, fromCurrentTransform, startdate, animationname)
 		  c.BackgroundColor = NewColor
 		  commitAnimations
@@ -1232,7 +1239,7 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub setBoundsAnimated(extends c as ioscontrol, NewBounds as Xojo.Core.rect, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef ="")
+		Sub setBoundsAnimated(extends c as ioscontrol, NewBounds as Xojo.Core.rect, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef = "")
 		  c.setOldAnimationProperties (Seconds, delay, curve, transition, cacheTransition, repeat, autoreverse, continueFromCurrentState, fromCurrentTransform, startdate, animationname)
 		  c.Bounds = NewBounds
 		  commitAnimations
@@ -1249,7 +1256,7 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub setCenterAnimated(extends c as ioscontrol, NewCenter as Xojo.Core.point, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef ="")
+		Sub setCenterAnimated(extends c as ioscontrol, NewCenter as Xojo.Core.point, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef = "")
 		  c.setOldAnimationProperties (Seconds, delay, curve, transition, cacheTransition, repeat, autoreverse, continueFromCurrentState, fromCurrentTransform, startdate, animationname)
 		  c.Center = NewCenter
 		  commitAnimations
@@ -1282,12 +1289,12 @@ Protected Module iOSControlExtension
 	#tag Method, Flags = &h1
 		Protected Sub setFrame(id as ptr, value as CGRect)
 		  declare Sub setFrame lib UIKit selector "setFrame:" (id as ptr, value as cgrect)
-		   setFrame id, value
+		  setFrame id, value
 		End Sub
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub setFrameAnimated(extends c as ioscontrol, NewFrame as Xojo.Core.rect, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef ="")
+		Sub setFrameAnimated(extends c as ioscontrol, NewFrame as Xojo.Core.rect, Seconds as Double = 0.2, delay as double = 0, curve as AnimationCurve = animationcurve.easeInEaseOut, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean = True, repeat as single = 0, autoreverse as boolean = false, continueFromCurrentState as Boolean = True, fromCurrentTransform as Boolean = false, startdate as xojo.core.date = NIL, animationname as CFStringRef = "")
 		  c.setOldAnimationProperties (Seconds, delay, curve, transition, cacheTransition, repeat, autoreverse, continueFromCurrentState, fromCurrentTransform, startdate, animationname)
 		  c.Frame = NewFrame
 		  commitAnimations
@@ -1304,7 +1311,7 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Sub setLayerClass(id as ptr,  value as ptr)
+		Protected Sub setLayerClass(id as ptr, value as ptr)
 		  declare sub setlayerClass lib UIKit selector "setLayerClass:" (id as ptr, value as ptr)
 		  setlayerClass id, value
 		End Sub
@@ -1318,14 +1325,14 @@ Protected Module iOSControlExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Sub setMultipleTouchEnabled(id as ptr,  value as boolean)
+		Protected Sub setMultipleTouchEnabled(id as ptr, value as boolean)
 		  declare Sub multipleTouchEnabled lib UIKit selector "multipleTouchEnabled:" (id as ptr, value as Boolean)
 		  setmultipleTouchEnabled id, value
 		End Sub
 	#tag EndMethod
 
 	#tag Method, Flags = &h21
-		Private Sub setOldAnimationProperties(extends c as ioscontrol, Seconds as Double, delay as double, curve as AnimationCurve, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean, repeat as single,  autoreverse as boolean, continueFromCurrentState as Boolean, fromCurrentTransform as Boolean, startdate as xojo.core.date, animationname as CFStringRef)
+		Private Sub setOldAnimationProperties(extends c as ioscontrol, Seconds as Double, delay as double, curve as AnimationCurve, transition as oldtransitionmode = oldtransitionmode.none, cacheTransition as Boolean, repeat as single, autoreverse as boolean, continueFromCurrentState as Boolean, fromCurrentTransform as Boolean, startdate as xojo.core.date, animationname as CFStringRef)
 		  beginAnimations  animationname, NIL
 		  setAnimationDuration Seconds
 		  setAnimationDelay delay
@@ -1492,7 +1499,7 @@ Protected Module iOSControlExtension
 
 	#tag Method, Flags = &h0
 		Sub TintColor(extends c as iOSControl, assigns aColor as Color)
-		  setTintColor c.handle, aColor.uicolor
+		  setTintColor c.handle, aColor.touicolor
 		End Sub
 	#tag EndMethod
 

--- a/iOSControls/Class Extensions/iOSTableExtension.xojo_code
+++ b/iOSControls/Class Extensions/iOSTableExtension.xojo_code
@@ -60,6 +60,32 @@ Protected Module iOSTableExtension
 		End Sub
 	#tag EndMethod
 
+	#tag Method, Flags = &h1
+		Protected Function Cell(extends a as iostable, row as integer, section as integer) As Ptr
+		  dim IP as new NSIndexPath (row, section)
+		  return getcellForRowAtIndexPath (a.Handle, IP)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub CellBackgroundColor(extends a as iostable, row as integer, section as integer, assigns aColor as color)
+		  dim aCell as Ptr = a.cell (row, section)
+		  setcellbackgroundcolor (acell, acolor)
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub CellsBackgroundColor(extends a as iOSTable, assigns aColor as color)
+		  for section as integer = 0 to a.SectionCount - 1
+		    for row as integer = 0 to a.RowCount (section) -1
+		      dim aCell as Ptr = a.cell (row, section)
+		      setcellbackgroundcolor acell, acolor
+		    next
+		  next
+		  // timer.CallLater 200, AddressOf a.reloaddata
+		End Sub
+	#tag EndMethod
+
 	#tag Method, Flags = &h0
 		Function ContentInset(extends a as iOSTable) As UIEdgeInsets64Bit
 		  return iOSTextAreaExtension.getcontentInset (a.handle)
@@ -100,6 +126,12 @@ Protected Module iOSTableExtension
 		Sub ContentSize(extends a as iostable, assigns value as xojo.core.size)
 		  iOSTextAreaExtension.setcontentSize a.handle, value.tocgsize
 		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function DataSourcePtr(extends a as iOSTable) As Ptr
+		  return getdataSource (a.handle)
+		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
@@ -144,6 +176,54 @@ Protected Module iOSTableExtension
 		End Sub
 	#tag EndMethod
 
+	#tag Method, Flags = &h0
+		Function FooterViewForSection(extends a as iostable, section as integer) As Ptr
+		  return getFooterViewForSection (a.handle, section)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getbackgroundView(id as ptr) As Ptr
+		  declare function backgroundView lib uikit selector "backgroundView" (id as ptr) as Ptr
+		  return backgroundView (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getcellForRowAtIndexPath(id as ptr, IndexPath as NSIndexPath) As Ptr
+		  declare function cellForRowAtIndexPath lib uikit selector "cellForRowAtIndexPath:" (id as ptr, indexpath as ptr) as Ptr
+		  return cellForRowAtIndexPath (id, indexpath.Handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getdataSource(id as ptr) As Ptr
+		  declare function dataSource lib uikit selector "dataSource" (id as ptr) as Ptr
+		  return dataSource (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getFooterViewForSection(id as ptr, section as integer) As Ptr
+		  declare function footerViewForSection lib uikit selector "footerViewForSection:" (id as ptr, section as integer) as Ptr
+		  return footerViewForSection (id, section)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getheaderViewForSection(id as ptr, section as integer) As Ptr
+		  declare function headerViewForSection lib uikit selector "headerViewForSection:" (id as ptr, section as integer) as Ptr
+		  return headerViewForSection (id, section)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getindexPathForCell(id as ptr, cell as ptr) As Ptr
+		  declare function indexPathForCell_ lib uikit selector "indexPathForCell:" (id as ptr, cell as ptr) as Ptr
+		  return indexPathForCell_ (id, cell)
+		End Function
+	#tag EndMethod
+
 	#tag Method, Flags = &h1
 		Protected Function getRowHeight(id as ptr) As double
 		  #if target64bit
@@ -152,6 +232,81 @@ Protected Module iOSTableExtension
 		    declare function rowHeight lib uikit selector "rowHeight" (id as ptr) as single
 		  #endif
 		  return rowheight (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getSectionFooterHeight(id as ptr) As double
+		  #if target64bit
+		    declare function sectionFooterHeight lib uikit selector "sectionFooterHeight" (id as ptr) as double
+		  #elseif Target32Bit
+		    declare function sectionFooterHeight lib uikit selector "sectionFooterHeight" (id as ptr) as single
+		  #endif
+		  return sectionFooterHeight (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getSectionHeaderHeight(id as ptr) As double
+		  #if target64bit
+		    declare function sectionHeaderHeight lib uikit selector "sectionHeaderHeight" (id as ptr) as double
+		  #elseif Target32Bit
+		    declare function sectionHeaderHeight lib uikit selector "sectionHeaderHeight" (id as ptr) as single
+		  #endif
+		  return sectionHeaderHeight (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getSeparatorColor(id as ptr) As Ptr
+		  declare function separatorColor lib uikit selector "separatorColor" (id as ptr) as Ptr
+		  return separatorColor (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getseparatorInset(id as ptr) As UIEdgeInsets64Bit
+		  #if target32bit
+		    declare function separatorInset lib UIKit selector "separatorInset" (id as ptr) as UIEdgeInsets32Bit
+		    dim myInsets as UIEdgeInsets32Bit = separatorInset (id)
+		    return iOSTextAreaExtension.Inset32toInset64 (myInsets)
+		  #elseif target64bit
+		    declare function separatorInset lib UIKit selector "separatorInset" (id as ptr) as UIEdgeInsets64Bit
+		    return separatorInset (id)
+		  #endif
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function getSeparatorStyle(id as ptr) As SeparatorStyles
+		  declare function separatorStyle lib uikit selector "separatorStyle" (id as ptr) as SeparatorStyles
+		  return separatorStyle (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function gettableFooterView(id as ptr) As Ptr
+		  declare function tableFooterView lib uikit selector "tableFooterView" (id as ptr) as Ptr
+		  return tableFooterView (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Function gettableHeaderView(id as ptr) As Ptr
+		  declare function tableHeaderView lib uikit selector "tableHeaderView" (id as ptr) as Ptr
+		  return tableHeaderView (id)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function HeaderViewForSection(extends a as iostable, section as integer) As Ptr
+		  return getheaderViewForSection (a.handle, section)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function IndexPathForCell(extends a as iostable, cell as iOSTableCellData) As NSIndexPath
+		  // return new NSIndexPath (getindexPathForCell (a.Handle, cell.Handle))
 		End Function
 	#tag EndMethod
 
@@ -294,6 +449,30 @@ Protected Module iOSTableExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
+		Function SectionFooterHeight(extends a as iOSTable) As double
+		  return getSectionFooterHeight (a.handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub SectionFooterHeight(extends a as iOSTable, assigns value as double)
+		  setsectionFooterHeight a.handle, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function SectionHeaderHeight(extends a as iOSTable) As double
+		  return getSectionHeaderHeight (a.handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub SectionHeaderHeight(extends a as iOSTable, assigns value as double)
+		  setsectionHeaderHeight a.handle, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
 		Function Selectable(extends a as iOSTable) As Boolean
 		  return iOSTextAreaExtension.getSelectable (a.handle)
 		End Function
@@ -305,6 +484,65 @@ Protected Module iOSTableExtension
 		End Sub
 	#tag EndMethod
 
+	#tag Method, Flags = &h0
+		Function SeparatorColor(extends a as iostable) As color
+		  return getSeparatorColor (a.handle).tocolor
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub SeparatorColor(extends a as iostable, assigns value as color)
+		  setSeparatorColor a.handle, value.touicolor
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function SeparatorInset(extends a as iostable) As UIEdgeInsets64Bit
+		  return getseparatorInset (a.handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub SeparatorInset(extends a as iostable, assigns value as UIEdgeInsets64Bit)
+		  setseparatorInset a.handle, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function SeparatorStyle(extends a as iostable) As SeparatorStyles
+		  return getSeparatorStyle (a.handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub SeparatorStyle(extends a as iostable, assigns value as SeparatorStyles)
+		  setSeparatorStyle a.handle, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub setbackgroundView(id as ptr, value as ptr)
+		  declare sub setbackgroundView_ lib uikit selector "setBackgroundView:" (id as ptr, value as ptr)
+		  setbackgroundView_ id, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub SetCellBackgroundColor(cell as ptr, aColor as color)
+		  iOSControlExtension.setBackgroundColor (cell, acolor.touicolor)
+		  dim bgview as ptr = getbackgroundView (cell) // the background view feature doesn't help. This all has to be redone once a datasource cell paint event is available.
+		  if bgview = nil then
+		    dim newview as new uiview (CoreRectExtension.fromCGRect (iOSControlExtension.getBounds(cell)))
+		    setbackgroundView cell, newview.id
+		  end if
+		  
+		  iOSControlExtension.setBackgroundColor getbackgroundView (Cell), aColor.toUIColor // setting the color for bg view too.
+		  dim mycolor as color = iOSControlExtension.getBackgroundColor(cell).tocolor // and looking what color is really inside now
+		  system.debuglog if (mycolor = aColor, "Colors match", "Colors don't match")+" : "+aColor.totext+", "+mycolor.totext
+		  
+		End Sub
+	#tag EndMethod
+
 	#tag Method, Flags = &h1
 		Protected Sub setRowHeight(id as ptr, value as double)
 		  #if target64bit
@@ -313,6 +551,68 @@ Protected Module iOSTableExtension
 		    declare sub setRowHeight lib uikit selector "setRowHeight:" (id as ptr, value as single)
 		  #endif
 		  setrowheight id, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub setsectionFooterHeight(id as ptr, value as double)
+		  #if target64bit
+		    declare sub setsectionFooterHeight_ lib uikit selector "setSectionFooterHeight:" (id as ptr, value as double)
+		  #elseif Target32Bit
+		    declare sub setsectionFooterHeight_ lib uikit selector "setSectionFooterHeight:" (id as ptr, value as single)
+		  #endif
+		  setSectionFooterHeight_ id, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub setsectionHeaderHeight(id as ptr, value as double)
+		  #if target64bit
+		    declare sub setSectionHeaderHeight_ lib uikit selector "setSectionHeaderHeight:" (id as ptr, value as double)
+		  #elseif Target32Bit
+		    declare sub setSectionHeaderHeight_ lib uikit selector "setSectionHeaderHeight:" (id as ptr, value as single)
+		  #endif
+		  setSectionHeaderHeight_ id, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub setSeparatorColor(id as ptr, value as ptr)
+		  declare sub setSeparatorColor_ lib uikit selector "setSeparatorColor:" (id as ptr, value as ptr)
+		  setSeparatorColor_ id, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub setseparatorInset(id as ptr, value as UIEdgeInsets64Bit)
+		  #if target32bit
+		    declare sub setSeparatorInset_ lib UIKit selector "setSeparatorInset:" (id as ptr, value as UIEdgeInsets32Bit)
+		    setSeparatorInset_ id, iOSTextAreaExtension.Inset64toInset32 (value)
+		  #elseif target64bit
+		    declare sub setSeparatorInset_ lib UIKit selector "setSeparatorInset:" (id as ptr, value as UIEdgeInsets64Bit)
+		    setSeparatorInset_ id, value
+		  #endif
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub setSeparatorStyle(id as ptr, value as SeparatorStyles)
+		  declare sub setseparatorStyle_ lib uikit selector "setSeparatorStyle:" (id as ptr, value as SeparatorStyles)
+		  setseparatorStyle_ id, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub settableFooterView(id as ptr, value as ptr)
+		  declare sub settableFooterView_ lib uikit selector "setTableFooterView:" (id as ptr, value as ptr)
+		  settableFooterView_ id, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h1
+		Protected Sub settableHeaderView(id as ptr, value as ptr)
+		  declare sub settableHeaderView_ lib uikit selector "setTableHeaderView:" (id as ptr, value as ptr)
+		  settableHeaderView_ id, value
 		End Sub
 	#tag EndMethod
 
@@ -337,6 +637,42 @@ Protected Module iOSTableExtension
 	#tag Method, Flags = &h0
 		Sub ShowsVerticalScrollBar(extends a as iostable, assigns value as boolean)
 		  iOSTextAreaExtension.setshowsVerticalScrollIndicator a.Handle, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function TableFooterView(extends a as iOSTable) As Ptr
+		  return gettableFooterView (a.Handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub TableFooterView(extends a as iOSTable, assigns value as ptr)
+		  settableFooterView a.Handle, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function TableHeaderView(extends a as iOSTable) As Ptr
+		  return gettableHeaderView (a.Handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub TableHeaderView(extends a as iOSTable, assigns value as ptr)
+		  settableHeaderView a.Handle, value
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function ViewHandle(extends a as iOSTable) As Ptr
+		  return getbackgroundView (a.Handle)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub ViewHandle(extends a as iOSTable, assigns value as ptr)
+		  setbackgroundView a.Handle, value
 		End Sub
 	#tag EndMethod
 
@@ -421,6 +757,9 @@ Protected Module iOSTableExtension
 		
 		– CanCancelContentTouches: If True, initiates a scroll that started with a touch that was registered by an underlying view. If False, the view will not scroll.
 		
+		– CellBackgroundColor (row, section) (Color): Lets you set the backgroundcolor for the cell in row/section.
+		   * There seems to be an error, the cell colors are not consistent and change when you scroll back & forth. *
+		
 		– ContentInset (UIEdgeInset): The inset in points for top.left, bottom and right indentation. I find this seems to work rather strange – maybe a problem of the 32/64 bit handling?
 		
 		– ContentOffset (Xojo.Core.Point): sets the offset of the contents. To raise indentation, feed it with negative values.
@@ -428,6 +767,9 @@ Protected Module iOSTableExtension
 		– ContentOffsetAnimated (Xojo.Core.Point, write-only): same as above but animates the change.
 		
 		– ContentSize (Size): TheSize in Points of the view's content
+		
+		– DataSourcePtr (Ptr, Read-only): The dataSource object of the table. Could basically be a write function too but you would have to design a custom DataSource object.
+		   Used for row handling by some functions.
 		
 		– DelaysContentTouches (Boolean): If true, holds back a touch event until it is sure it is no scroll event (or it is one).
 		
@@ -461,13 +803,29 @@ Protected Module iOSTableExtension
 		
 		– ScrollToTopEnabled (Boolean): Enables the Tap on status bar gesture to scroll to the top.
 		
+		– SectionFooterHeight (Double): The height of section footers.
+		
+		– SectionHeaderHeight (Double): The height of section headers.
+		
 		– Selectable (Boolean): Sets the user's ability to select content and interact with URLs and attachments.
+		
+		– SeparatorColor (Color): Lets you set the row separator line color
+		
+		– SeparatorInset (UIEdgeInsets64Bit): The default inset for all cells in the table. Only left and right values are used.
+		
+		– SeparatorStyle (SeparatorStyles): Lets you chose between No, SingleLine and Etched Single Line Style.
 		
 		– ShowsHorizontalScrollbar (Boolean): Whether the horizontal scrollbar appears.
 		
 		– ShowsVerticalScrollbar (Boolean): Whether the vertical scrollbar appears.
 		
-		– ZoomScale (Double):The zoom scale of the content
+		– TableFooterView (Ptr): Ptr to an accessory view below the table. Standard is NIL.
+		
+		– TableHeaderView (Ptr): Ptr to an accessory view above the table. Standard is NIL.
+		
+		– ViewHandle (Ptr): A Ptr to the table's background view which is placed behind all cells etc. Set to NIL if you want to set the table's backgroundcolor.
+		
+		– ZoomScale (Double): The zoom scale of the content
 		
 		– ZoomScaleAnimated (Double, write-only): The content gets scaled with an animation.
 		   Both don't seem to work with iosTables. Probably only useful for other scrollViews. If it proves to be so, the Zoom objects should probably better be removed.
@@ -478,6 +836,10 @@ Protected Module iOSTableExtension
 		* Methods *
 		
 		– flashScrollIndicators(): Shows the scroll bars temporarily
+		
+		– FooterViewForSection (Section as Integer): A Ptr to the section's footer view
+		
+		– HeaderiewForSection (Section as Integer): A Ptr to the section's header view
 		
 		– ScrollToRange (aRange asNSRange): Scrolls the text to show the selected range.
 		
@@ -499,6 +861,13 @@ Protected Module iOSTableExtension
 		
 		
 	#tag EndNote
+
+
+	#tag Enum, Name = SeparatorStyles, Type = Integer, Flags = &h1
+		None
+		  SingleLine
+		SingleLineEtched
+	#tag EndEnum
 
 
 	#tag ViewBehavior

--- a/iOSControls/Class Extensions/iOSViewExtension.xojo_code
+++ b/iOSControls/Class Extensions/iOSViewExtension.xojo_code
@@ -27,7 +27,7 @@ Protected Module iOSViewExtension
 
 	#tag Method, Flags = &h0
 		Sub BackgroundColor(extends v as iOSView, assigns value as color)
-		  iOSControlExtension.setBackgroundColor getView (v.handle), value.uicolor
+		  iOSControlExtension.setBackgroundColor getView (v.handle), value.touicolor
 		End Sub
 	#tag EndMethod
 

--- a/iOSControls/DataType Extensions/ColorExtension.xojo_code
+++ b/iOSControls/DataType Extensions/ColorExtension.xojo_code
@@ -11,7 +11,7 @@ Protected Module ColorExtension
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function UIColor(extends c as color) As Ptr
+		Function toUIColor(extends c as color) As Ptr
 		  // returns a Ptr to a new Uicolor Created from a Xojo Color
 		  
 		  declare function colorFromRGBA lib UIKit selector "colorWithRed:green:blue:alpha:" (id as Ptr, red as Single, green as Single, blue as Single, alpha as Single) as Ptr

--- a/iOSControls/DataType Extensions/PtrExtension.xojo_code
+++ b/iOSControls/DataType Extensions/PtrExtension.xojo_code
@@ -51,7 +51,7 @@ Protected Module PtrExtension
 
 	#tag Method, Flags = &h0
 		Function toAutoArray(extends NSArray as Ptr) As Auto()
-		   // Converts an NSArray to a Xojo Array
+		  // Converts an NSArray to a Xojo Array
 		  
 		  dim myarray() as Auto
 		  for q as uinteger = 0 to NSArray.count -1
@@ -84,7 +84,7 @@ Protected Module PtrExtension
 
 	#tag Method, Flags = &h0
 		Function toIOSImageArray(extends NSArray as Ptr) As iosimage()
-		   // Converts an NSArray to a Xojo Array
+		  // Converts an NSArray to a Xojo Array
 		  
 		  dim myarray() as iOSImage
 		  for q as uinteger = 0 to NSArray.count -1
@@ -96,7 +96,7 @@ Protected Module PtrExtension
 
 	#tag Method, Flags = &h0
 		Function toPtrArray(extends NSArray as Ptr) As Ptr()
-		   // Converts an NSArray to a Xojo Array
+		  // Converts an NSArray to a Xojo Array
 		  
 		  dim myarray() as Ptr
 		  for q as uinteger = 0 to NSArray.count -1

--- a/iOSControls/iosClasses/NSIndexPath.xojo_code
+++ b/iOSControls/iosClasses/NSIndexPath.xojo_code
@@ -1,0 +1,162 @@
+#tag Class
+Protected Class NSIndexPath
+	#tag Method, Flags = &h0
+		Sub Constructor(row as integer, section as integer)
+		  declare function indexPathForRow lib UIKit selector "indexPathForRow:inSection:" (id as ptr, row as integer, section as integer) as ptr
+		  mHandle = indexPathForRow (ClassPtr, row, section)
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Sub Constructor(Id as Ptr)
+		  mHandle = id
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function IndexAtPosition(Node as UInteger) As UInteger
+		  declare Function IndexAtPosition_ lib UIKit selector "IndexAtPosition:" (id as ptr, Node as uinteger) as UInteger
+		  return IndexAtPosition_ (Handle, node)
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function indexPathByAddingIndex(Index as UInteger) As NSIndexPath
+		  declare Function indexPathByAddingIndex_ lib UIKit selector "indexPathByAddingIndex:" (id as ptr, index as uinteger) as Ptr
+		  return new NSIndexPath (indexPathByAddingIndex_ (Handle, index))
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
+		Function indexPathByRemovingLastIndex() As NSIndexPath
+		  declare Function indexPathByRemovingLastIndex_ lib UIKit selector "indexPathByRemovingLastIndex" (id as ptr) as Ptr
+		  return new NSIndexPath (indexPathByRemovingLastIndex_ (Handle))
+		End Function
+	#tag EndMethod
+
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  static mClassPtr as Ptr = NSClassFromString ("NSIndexPath")
+			  return mClassPtr
+			End Get
+		#tag EndGetter
+		Shared ClassPtr As Ptr
+	#tag EndComputedProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  return mHandle
+			End Get
+		#tag EndGetter
+		Handle As Ptr
+	#tag EndComputedProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  declare Sub getIndexes lib uikit selector "getIndexes:" (id as ptr, byref indexes as ptr) 
+			  dim bytes as integer = 4
+			  #if target64bit
+			    bytes = 8
+			  #endif
+			  dim myptr as ptr
+			  getIndexes handle, myptr
+			  dim mb as new MutableMemoryBlock (myptr,bytes * length)
+			  return mb
+			  
+			  
+			End Get
+		#tag EndGetter
+		Indexes As Memoryblock
+	#tag EndComputedProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  declare Function item lib UIKit selector "item" (id as ptr) as integer
+			  return item (Handle)
+			End Get
+		#tag EndGetter
+		Item As Integer
+	#tag EndComputedProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  declare function length lib uikit selector "length" (id as ptr) as UInteger
+			  return length (Handle)
+			End Get
+		#tag EndGetter
+		Length As UInteger
+	#tag EndComputedProperty
+
+	#tag Property, Flags = &h21
+		Private mHandle As Ptr
+	#tag EndProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  declare Function row_ lib UIKit selector "row" (id as ptr) as integer
+			  return row_ (Handle)
+			End Get
+		#tag EndGetter
+		Row As Integer
+	#tag EndComputedProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  declare Function section_ lib UIKit selector "section" (id as ptr) as integer
+			  return Section_ (Handle)
+			End Get
+		#tag EndGetter
+		Section As Integer
+	#tag EndComputedProperty
+
+
+	#tag ViewBehavior
+		#tag ViewProperty
+			Name="Index"
+			Visible=true
+			Group="ID"
+			InitialValue="-2147483648"
+			Type="Integer"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Left"
+			Visible=true
+			Group="Position"
+			InitialValue="0"
+			Type="Integer"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="mHandle"
+			Group="Behavior"
+			Type="Integer"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Name"
+			Visible=true
+			Group="ID"
+			Type="String"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Super"
+			Visible=true
+			Group="ID"
+			Type="String"
+		#tag EndViewProperty
+		#tag ViewProperty
+			Name="Top"
+			Visible=true
+			Group="Position"
+			InitialValue="0"
+			Type="Integer"
+		#tag EndViewProperty
+	#tag EndViewBehavior
+End Class
+#tag EndClass

--- a/iOSControls/iosClasses/UIImageView.xojo_code
+++ b/iOSControls/iosClasses/UIImageView.xojo_code
@@ -2,7 +2,7 @@
 Protected Class UIImageView
 Inherits iOSImageView
 	#tag Method, Flags = &h0
-		Sub Animate(NewColor as Color, seconds as double,  options as uinteger = 0, delay as double = 0, withTransitions as Boolean = False)
+		Sub Animate(NewColor as Color, seconds as double, options as uinteger = 0, delay as double = 0, withTransitions as Boolean = False)
 		  TransformToBackgroundColor = NewColor
 		  dim block as new iOSBlock (AddressOf TransformColorBlock)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
@@ -30,7 +30,7 @@ Inherits iOSImageView
 	#tag Method, Flags = &h0
 		Sub Animate(Xfactor as Double, YFactor as Double, Seconds as Double = 0.2, options as uinteger = 0, delay as double = 0, fromoriginal as Boolean = false, withTransition as Boolean = false)
 		  Xfactor = Xfactor / 100
-		  if YFactor = 0 then 
+		  if YFactor = 0 then
 		    YFactor = Xfactor
 		  else
 		    YFactor = YFactor / 100
@@ -53,7 +53,7 @@ Inherits iOSImageView
 		Sub Animate(Degrees as single, Seconds as Double = 0.2, options as uinteger = 0, delay as double = 0, fromoriginal as boolean = true, withTransition as Boolean = False)
 		  dim radians as single = Degrees.DegreesToRadians
 		  transformtotransformation  = if (fromOriginal,  iOSControlExtension.CGAffineTransformMakeRotation (radians), _
-		   iOSControlExtension.CGAffineTransformRotate (Transform, radians))
+		  iOSControlExtension.CGAffineTransformRotate (Transform, radians))
 		  dim block as new iOSBlock (AddressOf TransformTransformationBlock)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
 		  if withTransition then
@@ -65,7 +65,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Animate(NewCenter as Xojo.core.Point, seconds as double = 0.2 , options as uinteger = 0, delay as double = 0, withTransition as Boolean = False)
+		Sub Animate(NewCenter as Xojo.core.Point, seconds as double = 0.2, options as uinteger = 0, delay as double = 0, withTransition as Boolean = False)
 		  TransformToCenter = NewCenter
 		  dim block as new iOSBlock (AddressOf TransformCenterBlock)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
@@ -111,7 +111,7 @@ Inherits iOSImageView
 		  
 		  TransFormToBackgroundColor = endcolor
 		  transformtotransformation = if (fromOriginal,  iOSControlExtension.CGAffineTransformMakeRotation (angle), _
-		   iOSControlExtension.CGAffineTransformRotate (Transform, angle))
+		  iOSControlExtension.CGAffineTransformRotate (Transform, angle))
 		  dim block as new iOSBlock (AddressOf TransformBlock)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
 		  if withTransistion then
@@ -165,7 +165,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub AnimateSpring(NewColor as Color, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0,  delay as Double = 0)
+		Sub AnimateSpring(NewColor as Color, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0, delay as Double = 0)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
 		  
 		  
@@ -177,7 +177,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub AnimateSpring(Alpha as Double, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0,  delay as Double = 0)
+		Sub AnimateSpring(Alpha as Double, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0, delay as Double = 0)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
 		  TransformToAlpha = alpha
 		  dim block as new iOSBlock (AddressOf TransformAlphaBlock)
@@ -186,7 +186,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub AnimateSpring(Xfactor as Double, Yfactor as Double, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0,  delay as Double = 0, fromoriginal as boolean = true)
+		Sub AnimateSpring(Xfactor as Double, Yfactor as Double, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0, delay as Double = 0, fromoriginal as boolean = true)
 		  Xfactor = Xfactor / 100
 		  if YFactor = 0 then
 		    YFactor = Xfactor
@@ -203,7 +203,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub AnimateSpring(Degrees as single, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0,  delay as Double = 0, fromoriginal as boolean = true)
+		Sub AnimateSpring(Degrees as single, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0, delay as Double = 0, fromoriginal as boolean = true)
 		  Dim radians as single = Degrees.DegreesToRadians
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
 		  transformtotransformation  = if (fromOriginal,  iOSControlExtension.CGAffineTransformMakeRotation (radians), _
@@ -214,7 +214,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub AnimateSpring(NewCenter as Xojo.core.Point, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0,  delay as Double = 0)
+		Sub AnimateSpring(NewCenter as Xojo.core.Point, seconds as double, DampingRatio as double = 1, velocity as double = 1, options as uinteger = 0, delay as Double = 0)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
 		  TransformToCenter = NewCenter
 		  dim block as new iOSBlock (AddressOf TransformCenterBlock)
@@ -241,7 +241,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub AnimateSpringAll(angle as Single, EndAlpha As Double, Endframe as xojo.core.rect, Endbounds as xojo.core.rect = NIL, endCenter as Xojo.Core.Point = NIL, endcolor as color, seconds as Double = 0.2,  DampingRatio as double = 1, velocity as double = 1, delay as double = 0, options as uinteger = 0, fromOriginal as Boolean = true)
+		Sub AnimateSpringAll(angle as Single, EndAlpha As Double, Endframe as xojo.core.rect, Endbounds as xojo.core.rect = NIL, endCenter as Xojo.Core.Point = NIL, endcolor as color, seconds as Double = 0.2, DampingRatio as double = 1, velocity as double = 1, delay as double = 0, options as uinteger = 0, fromOriginal as Boolean = true)
 		  TransformToAlpha = EndAlpha
 		  TransFormToFrame = if (Endframe= NIL, Frame, Endframe)
 		  TransFormToBounds = if (Endbounds = NIL, bounds, Endbounds)
@@ -249,7 +249,7 @@ Inherits iOSImageView
 		  
 		  TransFormToBackgroundColor = endcolor
 		  TransformToTransformation = if (fromOriginal,  iOSControlExtension.CGAffineTransformMakeRotation (angle), _
-		   iOSControlExtension.CGAffineTransformRotate (Transform, angle))
+		  iOSControlExtension.CGAffineTransformRotate (Transform, angle))
 		  dim block as new iOSBlock (AddressOf TransformBlock)
 		  dim completion as new iOSBlock (AddressOf CompletionBlock)
 		  animateWithSpring (classptr, seconds, DampingRatio, velocity, block.handle, completion.Handle, delay, options)
@@ -342,7 +342,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h21
-		Private Sub performSystemAnimation(id as Ptr, onviews as ptr, animations as ptr,  options as uinteger = 0, completion as ptr)
+		Private Sub performSystemAnimation(id as Ptr, onviews as ptr, animations as ptr, options as uinteger = 0, completion as ptr)
 		  Declare sub performSystemAnimation lib UIKit selector "performSystemAnimation:onViews:options:animations:completion:" _
 		  (id as ptr, onviews as ptr, options as uinteger, animations as ptr, completion as ptr)
 		  performSystemAnimation id, onviews,  options, Animations, completion
@@ -426,7 +426,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Sub transitionFromView(fromview as Ptr, toView as Ptr, duration as Double, options as  uinteger,  completion as ptr)
+		 Shared Sub transitionFromView(fromview as Ptr, toView as Ptr, duration as Double, options as uinteger, completion as ptr)
 		  dim uiviewptr as ptr = NSClassFromString ("UIView")
 		  Declare sub transitionFromView lib UIKit selector "transitionFromView:toView:duration:options:completion:" _
 		  (id as ptr, fromview as ptr, toview as ptr, duration as Double, options as uinteger, completion as ptr)
@@ -436,7 +436,7 @@ Inherits iOSImageView
 	#tag EndMethod
 
 	#tag Method, Flags = &h21
-		Private Sub transitionWithDuration(duration as Double, options as  uinteger, animations as ptr, completion as ptr)
+		Private Sub transitionWithDuration(duration as Double, options as uinteger, animations as ptr, completion as ptr)
 		  Declare sub transitionWithView lib UIKit selector "transitionWithView:duration:options:animations:completion:" _
 		  (id as ptr, view as ptr, duration as Double, options as uinteger, animations as ptr, completion as ptr)
 		  transitionWithView ClassPtr, id, duration, options,  animations, completion

--- a/iOSControls/iosClasses/UIView.xojo_code
+++ b/iOSControls/iosClasses/UIView.xojo_code
@@ -17,7 +17,7 @@ Inherits iosView
 	#tag Method, Flags = &h1000
 		Sub Constructor(aFrame as rect)
 		  dim myrect as CGRect = aFrame.tocGRect
-		  mid = iOSControlExtension.initWithFrame(iOSControlExtension.classptr, myrect)
+		  mid = iOSControlExtension.initWithFrame(alloc(iOSControlExtension.classptr), myrect)
 		End Sub
 	#tag EndMethod
 

--- a/iOSLib.xojo_project
+++ b/iOSLib.xojo_project
@@ -1,5 +1,5 @@
 Type=iOS
-RBProjectVersion=2014.031
+RBProjectVersion=2014.032
 MinIDEVersion=20140300
 Module=CorePointExtension;iOSControls/Class Extensions/CorePointExtension.xojo_code;&h480AE47D;&h34569DBF;false
 Module=CoreSizeExtension;iOSControls/Class Extensions/CoreSizeExtension.xojo_code;&h34D3968F;&h34569DBF;false
@@ -65,6 +65,7 @@ iOSView=TextAreaView;Views/TextAreaView.xojo_code;&hF8B53BA;&h3F16B090;false
 Module=iOSTextAreaExtension;iOSControls/Class Extensions/iOSTextAreaExtension.xojo_code;&h42621F5;&h34569DBF;false
 iOSView=TableView;Views/TableView.xojo_code;&h650998D2;&h3F16B090;false
 Module=iOSTableExtension;iOSControls/Class Extensions/iOSTableExtension.xojo_code;&h59107876;&h34569DBF;false
+Class=NSIndexPath;iOSControls/iosClasses/NSIndexPath.xojo_code;&h1DA082D2;&h243D469B;false
 DefaultTabletScreen=iPadScreen
 MajorVersion=1
 MinorVersion=0


### PR DESCRIPTION
Added a few background color methods to iOSTableExtension. They do not work reliably: A  datasource object/delegate would have to be constructed with a "cellpaint" event.
Renamed ColorExtension.UIColor to ColorExtensin.toUIColor to keep it alaigned with other methods.